### PR TITLE
Fix crash when typing in multibyte characters

### DIFF
--- a/autoload/leaderf/cli.py
+++ b/autoload/leaderf/cli.py
@@ -132,10 +132,10 @@ class LfCli(object):
             if self._isFuzzy:
                 if os.name == 'nt':
                     # treat '/' and '\' the same
-                    func = lambda c: r'[\\/].*?' if c == '\\' or c == '/' else '\^' if c == '^' else c if c.isalnum() else '['+c+']'
+                    func = lambda c: r'[\\/].*?' if c == '\\' or c == '/' else re.escape(c)
                     nonSlash = r'[^\\/]*?'
                 else:
-                    func = lambda c: '/.*?' if c == '/' else '\\'+c if (c == '\\' or c == '^') else c if c.isalnum() else '['+c+']'
+                    func = lambda c: '/.*?' if c == '/' else re.escape(c)
                     nonSlash = r'[^/]*?'
                 delimiter = vim.eval("g:Lf_DelimiterChar")
                 if self.isFileNameOnly and delimiter in self._cmdline:


### PR DESCRIPTION
When typing in multibyte characters like 'ö' and 'ä', LeaderF spits out error messages. The reason is that for the character 'ö' it creates a regexp like this: `[\xc3\xb6]` which matches every string that contains one of these two bytes (instead of strings that contain _exactly_ these two bytes). That leads to false positives which produce these errors. My patch fixes it (and is a little bit easier ;)

By the way, LeaderF looks really promising so far. But a feature that I would really like to have, and all those CtrlPs and other CtrlP-like plugins lack, is a smooth way to browse through your file system. That means, without all the time including recursively all files in the current directory. Do you plan to include such a feature or should I try myself to add it to LeaderF?
