### PR TITLE
Fixed capitalization in s:InitDict()

### DIFF
--- a/plugin/leaderf.vim
+++ b/plugin/leaderf.vim
@@ -46,7 +46,8 @@ function! <SID>InitDict(var, dict)
             for i in value
                 call filter(tmp, '!empty(filter(tmp[v:key], "v:val !=? i"))')
             endfor
-            let tmp[toupper(key)] = map(value, 'toupper(v:val)')
+            let tmp[substitute(key, '\<\a', '\=toupper(submatch(0))', 'g')] =
+                  \ map(value, 'substitute(v:val, "\\<\\a", "\\=toupper(submatch(0))", "g")')
         endfor
         exec 'let '.a:var.'='.string(tmp)
     endif


### PR DESCRIPTION
I fixed `s:InitDict()` behaviour.

**Expected behavior:**
`s:InitDict()` capitalize the key code string

**Current behavior:**
`s:InitDict()` uppercase whole key code string

**For example:**
_before `call <SID>InitDict('g:Lf_CommandMap', s:Lf_CommandMap)` ([plugin/leaderf.vim#L145](https://github.com/sgur/LeaderF/blob/master/plugin/leaderf.vim#L145))_

``` vim
let g:Lf_CommandMap = {
      \   '<down>': ['<Down>', '<C-J>', '<C-N>']
      \ , '<up>': ['<Up>', '<C-K>', '<C-P>']
      \ }
```

_after `call <SID>InitDict('g:Lf_CommandMap', s:Lf_CommandMap)`_

``` vim
let g:Lf_CommandMap = {
      \ ... <snip>,
      \ '<DOWN>': ['<DOWN>', '<C-J>', '<C-N>'],
      \ '<UP>': ['<UP>', '<C-K>', '<C-P>'],
      \ ... <snip>
      \ }
```

this uppercased string cannot be accepted by  `startExplAction()` in `manager.py`
