### PR TITLE
Make it possible to open files with spaces in filenames

### DIFF
--- a/autoload/leaderf/util.py
+++ b/autoload/leaderf/util.py
@@ -24,7 +24,7 @@ def escQuote(str):
     return "" if str is None else re.sub("'","''",str)
 
 def escSpecial(str):
-    return re.sub('(%|#|")', r"\\\1", str)
+    return re.sub('([%#" ])', r"\\\1", str)
 
 def lfOpen(file, mode = 'r', buffering = -1, encoding = None, errors = None, newline = None, closefd = True):
     if sys.version_info >= (3,0):


### PR DESCRIPTION
Am I the first one to notice that you can not open files with spaces in their name? Anyway, I fixed it.
