### PR TITLE
Restore user's original cursor settings on exit

### DIFF
--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -62,11 +62,13 @@ function! leaderf#LfPy(cmd)
     if v:version > 703
         exec g:Lf_py . a:cmd
     else
+        let old_gcr = &gcr
+        let old_t_ve = &t_ve
         try
             exec g:Lf_py . a:cmd
         catch /^Vim:Interrupt$/	" catch interrupts (CTRL-C)
-            set gcr&
-            set t_ve&
+            let &gcr = old_gcr
+            let &t_ve = old_t_ve
             let obj = substitute(a:cmd,'\..*', '', '')
             exec g:Lf_py . obj .".quit()"
             call getchar(0)

--- a/autoload/leaderf/cli.py
+++ b/autoload/leaderf/cli.py
@@ -11,6 +11,8 @@ from leaderf.util import *
 def ctrlCursor(func):
     @wraps(func)
     def deco(*args, **kwargs):
+        vim.command("let g:lf_old_gcr = &gcr")
+        vim.command("let g:lf_old_t_ve = &t_ve")
         vim.command("set gcr=a:invisible")
         vim.command("set t_ve=")
         try:
@@ -18,12 +20,12 @@ def ctrlCursor(func):
                 yield i
         finally:
             try:
-                vim.command("set gcr&")
-                vim.command("set t_ve&")
+                vim.command("let &gcr = g:lf_old_gcr")
+                vim.command("let &t_ve = g:lf_old_t_ve")
             except: #due to vim's bug, I have to do like this
                 try:
-                    vim.command("set gcr&")
-                    vim.command("set t_ve&")
+                    vim.command("let &gcr = g:lf_old_gcr")
+                    vim.command("let &t_ve = g:lf_old_t_ve")
                 except:
                     pass
     return deco


### PR DESCRIPTION
Previously, LeaderF set the values of 'guicursor' and 't_ve' to Vim's default value when quitting, not to the user's setting.
