### PR TITLE
Bug fix for a crashing on Mac OSX

### DIFF
--- a/autoload/leaderf/mruExpl.py
+++ b/autoload/leaderf/mruExpl.py
@@ -18,7 +18,13 @@ class MruExplorer(Explorer):
     def getContent(self, *args, **kwargs):
         with lfOpen(mru.getCacheFileName(), 'r+', errors = 'ignore') as f:
             lines = f.readlines()
-            lines[:] = [name for name in lines if os.path.exists(name.rstrip())]
+            if '1' == vim.eval("g:Lf_MruInCurDirOnly"):
+                cwd = os.getcwd()
+#filter out the file 
+                lines[:] = [name for name in lines if name.startswith(cwd) and os.path.exists(name.rstrip())]
+            else:
+                vim.command("echom 'not in mru'")
+                lines[:] = [name for name in lines if os.path.exists(name.rstrip())]
             f.seek(0)
             f.truncate(0)
             f.writelines(lines)

--- a/autoload/leaderf/utils.py
+++ b/autoload/leaderf/utils.py
@@ -31,6 +31,8 @@ else: # python 2.x
             else:
                 return str.decode(locale.getdefaultlocale()[1]).encode(
                         vim.eval("&encoding"))
+        except ValueError:
+            return str
         except UnicodeDecodeError:
             return str
 

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -124,6 +124,12 @@ g:Lf_FollowLinks                                *g:Lf_FollowLinks*
     1 - yes
     Default value is 0.
 
+g:Lf_MruInCurDirOnly                             *g:Lf_MruInCurDirOnly*
+    Whether only show mru files under the current working dir.
+    0 - no
+    1 - yes
+    Default value is 0.
+
 g:Lf_WildIgnore                                 *g:Lf_WildIgnore*
     Specify the files and directories you want to exclude while indexing.
     Default value is: >

--- a/plugin/leaderf.vim
+++ b/plugin/leaderf.vim
@@ -98,6 +98,7 @@ call s:InitVar('g:Lf_FollowLinks', 0)
 call s:InitVar('g:Lf_DelimiterChar', ';')
 call s:InitVar('g:Lf_MruFileExclude', [])
 call s:InitVar('g:Lf_MruMaxFiles', 100)
+call s:InitVar('g:Lf_MruInCurDirOnly', 0)
 call s:InitVar('g:Lf_WildIgnore',{
             \ 'dir': ['.svn','.git'],
             \ 'file': ['*.sw?','~$*','*.bak','*.exe','*.o','*.so','*.py[co]']


### PR DESCRIPTION
I suffered a crashing on Mac OSX , caused by raising an uncaught `ValueError` exception with the following  stack:

```python
Error detected while processing function leaderf#startFileExpl[2]..leaderf#LfPy:
line    2:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/manager.py", line 443, in startExplorer
    self._content = self._getExplorer().getContent(*args, **kwargs)
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/fileExpl.py", line 172, in getContent
    self._content = self._getFileList(dir)
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/fileExpl.py", line 21, in deco
    cwd_length = len(lfEncoding(dir))
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/utils.py", line 29, in lfEncoding
    if locale.getdefaultlocale()[1] is None:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 543, in getdefaultlocale
    return _parse_localename(localename)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 475, in _parse_localename
    raise ValueError, 'unknown locale: %s' % localename
ValueError: unknown locale: UTF-8
```

I checked and it looks like it's caused by `getdefaultlocale` when I don't set LC_ALL and LANG in my env. OSX user can avoid this issue by adding the following code to their .bash_profile file (or .zshrc if you use zsh) as well.

```shell
export LC_ALL=en_US.UTF-8
export LANG=en_US.UTF-8
```

I don't know why my latest commit was included into this pull request. I make a new switch to decide whether you wanna see the mru files in other directory. When you set the switch to 1, you will only see the files under current directory. My aim is to work fix the issue#18 , hope this can be merged.