### PR TITLE
[Bug fix]avoid crashing on Mac OSX

### DIFF
--- a/autoload/leaderf/utils.py
+++ b/autoload/leaderf/utils.py
@@ -31,6 +31,8 @@ else: # python 2.x
             else:
                 return str.decode(locale.getdefaultlocale()[1]).encode(
                         vim.eval("&encoding"))
+        except ValueError:
+            return str
         except UnicodeDecodeError:
             return str
 


### PR DESCRIPTION
When LC_ALL and LANG envs are both empty, the python code will raise an exception and get the following crash stack:

```python
Error detected while processing function leaderf#startFileExpl[2]..leaderf#LfPy:
line    2:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/manager.py", line 443, in startExplorer
    self._content = self._getExplorer().getContent(*args, **kwargs)
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/fileExpl.py", line 172, in getContent
    self._content = self._getFileList(dir)
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/fileExpl.py", line 21, in deco
    cwd_length = len(lfEncoding(dir))
  File "/Users/xxx/.vim/bundle/LeaderF/autoload/leaderf/utils.py", line 29, in lfEncoding
    if locale.getdefaultlocale()[1] is None:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 543, in getdefaultlocale
    return _parse_localename(localename)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 475, in _parse_localename
    raise ValueError, 'unknown locale: %s' % localename
ValueError: unknown locale: UTF-8
```
