### PR TITLE
'modifiable' attribute must have a Boolean value

### DIFF
--- a/autoload/leaderf/instance.py
+++ b/autoload/leaderf/instance.py
@@ -193,7 +193,7 @@ class LfInstance(object):
         self._after_exit()
 
     def setBuffer(self, content):
-        self.buffer.options['modifiable'] = 1
+        self.buffer.options['modifiable'] = True
         self._buffer_object[:] = content
 
     @property

--- a/autoload/leaderf/instance.py
+++ b/autoload/leaderf/instance.py
@@ -93,7 +93,7 @@ class LfInstance(object):
 
         # clear the buffer first to avoid a flash
         if self._buffer_object:
-            self.buffer.options['modifiable'] = 1
+            self.buffer.options['modifiable'] = True
             del self._buffer_object[:]
 
         if win_pos == 'bottom':

--- a/autoload/leaderf/manager.py
+++ b/autoload/leaderf/manager.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import vim
-import re
 import operator
 from functools import partial
 from functools import wraps
@@ -15,9 +14,9 @@ from leaderf.fuzzyMatch import FuzzyMatch
 def modifiableController(func):
     @wraps(func)
     def deco(self, *args, **kwargs):
-        self._getInstance().buffer.options['modifiable'] = 1
+        self._getInstance().buffer.options['modifiable'] = True
         func(self, *args, **kwargs)
-        self._getInstance().buffer.options['modifiable'] = 0
+        self._getInstance().buffer.options['modifiable'] = False
     return deco
 
 #*****************************************************
@@ -477,7 +476,7 @@ class Manager(object):
             return
 
         if normal_mode: # when called in Normal mode
-            self._getInstance().buffer.options['modifiable'] = 1
+            self._getInstance().buffer.options['modifiable'] = True
 
         self._getInstance().setBuffer(self._content)
         if self._cli.pattern:
@@ -487,7 +486,7 @@ class Manager(object):
         if normal_mode: # when called in Normal mode
             self._createHelpHint()
             self._resetHighlights()
-            self._getInstance().buffer.options['modifiable'] = 0
+            self._getInstance().buffer.options['modifiable'] = False
 
     def addSelections(self):
         nr = self._getInstance().window.number


### PR DESCRIPTION
On neovim version 0.2.0-480-g25427ae89, I was unable to use the \<leader\>f shortcut.  The below fixed it for me.  I hope this can help others.