### PR TITLE
Fix hang when the instance buffer is wiped

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -217,7 +217,7 @@ class Manager(object):
         return True
 
     def _getInstance(self):
-        if self._instance is None:
+        if self._instance is None or self._instance.buffer not in vim.buffers:
             self._instance = LfInstance(self._getExplorer().getStlCategory(),
                                         self._beforeEnter,
                                         self._afterEnter,


### PR DESCRIPTION
To reproduce the problem:

* execute `:LeaderfFile`
* close the window with `Ctrl+C`
* execute `:%bw`
* execute `:LeaderfFile`