### PR TITLE
Win32 下 MRU 文件名归一化优化，怎加一些边界情况判断

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -230,8 +230,9 @@ class Manager(object):
             return
         help = []
         if not self._show_help:
-            help.append('" Press <F1> for help')
-            help.append('" ---------------------------------------------------------')
+			if lfEval("get(g:, 'Lf_HideHelp', 0)") == '0':
+				help.append('" Press <F1> for help')
+				help.append('" ---------------------------------------------------------')
         else:
             help += self._createHelp()
         self._help_length = len(help)

--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -230,9 +230,9 @@ class Manager(object):
             return
         help = []
         if not self._show_help:
-			if lfEval("get(g:, 'Lf_HideHelp', 0)") == '0':
-				help.append('" Press <F1> for help')
-				help.append('" ---------------------------------------------------------')
+            if lfEval("get(g:, 'Lf_HideHelp', 0)") == '0':
+                help.append('" Press <F1> for help')
+                help.append('" ---------------------------------------------------------')
         else:
             help += self._createHelp()
         self._help_length = len(help)

--- a/autoload/leaderf/python/leaderf/mru.py
+++ b/autoload/leaderf/python/leaderf/mru.py
@@ -38,6 +38,9 @@ class Mru(object):
             name = os.path.expanduser(name)
         name = os.path.abspath(name)
         if sys.platform[:3] == 'win':
+            if name[:4] == '\\\\?\\' and os.path.isabs(name):
+                if os.path.isabs(name[4:]) and name[5:6] == ':':
+                    name = name[4:]
             if name[1:3] == ':\\':
                 name = name[:1].upper() + name[1:]
         elif sys.platform == 'cygwin':


### PR DESCRIPTION
我最近再用 LanguageClient，它给我搞跳转时，有时候文件名被弄成：

```text
\\?\D:\ACM\github\BasicBitmap\BasicBitmap.cpp
```

导致又出现重复文件：

```text
BasicBitmap.h              "D:\ACM\github\BasicBitmap\"
BasicBitmap.h              "E:\Lesson\lesson\encoder\"
BasicBitmap.cpp            "D:\ACM\github\BasicBitmap\"
BasicBitmap.cpp            "\\?\D:\ACM\github\BasicBitmap\"
BasicBitmap.cpp            "E:\Lesson\lesson\encoder\"
```

我测试了一下 python 的 os.path.isabs 测试哪个 `\\?\` 开头的路径，居然返回 True，我不知道 language server 怎么搞的居然会给我打开这种名字的文件，所以加了点处理代码。麻烦 review 以下。