### PR TITLE
Fix the error if buffer list empty

### DIFF
--- a/autoload/leaderf/python/leaderf/bufExpl.py
+++ b/autoload/leaderf/python/leaderf/bufExpl.py
@@ -39,9 +39,10 @@ class BufferExplorer(Explorer):
         bufnr_len = len(lfEval("bufnr('$')"))
         self._prefix_length = bufnr_len + 8
 
-        self._max_bufname_len = max(int(lfEval("strdisplaywidth('%s')"
-                                        % escQuote(getBasename(buffers[nr].name))))
-                                    for nr in mru.getMruBufnrs() if nr in buffers)
+        self._max_bufname_len = max((int(lfEval("strdisplaywidth('%s')"
+                                         % escQuote(getBasename(buffers[nr].name))))
+                                     for nr in mru.getMruBufnrs() if nr in buffers),
+                                    default=0)
 
         bufnames = []
         for nr in mru.getMruBufnrs():


### PR DESCRIPTION
There is an issue that the plugin will raise an exception if there is no buffers in the buffer list.

It can be shown by opening Vim, opening a help doc, setting the help window as  the only window and then calling LeaderfBuffer.