### PR TITLE
fix g:preview

### DIFF
--- a/autoload/leaderf/Line.vim
+++ b/autoload/leaderf/Line.vim
@@ -26,6 +26,14 @@ function! leaderf#Line#Maps()
     nnoremap <buffer> <silent> i             :exec g:Lf_py "lineExplManager.input()"<CR>
     nnoremap <buffer> <silent> <Tab>         :exec g:Lf_py "lineExplManager.input()"<CR>
     nnoremap <buffer> <silent> <F1>          :exec g:Lf_py "lineExplManager.toggleHelp()"<CR>
+    nnoremap <buffer> <silent> p             :exec g:Lf_py "lineExplManager._previewResult(True)"<CR>
+    nnoremap <buffer> <silent> j             j:exec g:Lf_py "lineExplManager._previewResult(False)"<CR>
+    nnoremap <buffer> <silent> k             k:exec g:Lf_py "lineExplManager._previewResult(False)"<CR>
+    nnoremap <buffer> <silent> <Up>          <Up>:exec g:Lf_py "lineExplManager._previewResult(False)"<CR>
+    nnoremap <buffer> <silent> <Down>        <Down>:exec g:Lf_py "lineExplManager._previewResult(False)"<CR>
+    nnoremap <buffer> <silent> <PageUp>      <PageUp>:exec g:Lf_py "lineExplManager._previewResult(False)"<CR>
+    nnoremap <buffer> <silent> <PageDown>    <PageDown>:exec g:Lf_py "lineExplManager._previewResult(False)"<CR>
+    nnoremap <buffer> <silent> <LeftMouse>   <LeftMouse>:exec g:Lf_py "lineExplManager._previewResult(False)"<CR>
     if has_key(g:Lf_NormalMap, "Line")
         for i in g:Lf_NormalMap["Line"]
             exec 'nnoremap <buffer> <silent> '.i[0].' '.i[1]

--- a/autoload/leaderf/python/leaderf/functionExpl.py
+++ b/autoload/leaderf/python/leaderf/functionExpl.py
@@ -302,23 +302,6 @@ class FunctionExplManager(Manager):
     def removeCache(self, buf_number):
         self._getExplorer().removeCache(buf_number)
 
-    def _previewResult(self, preview):
-        if not self._needPreview(preview):
-            return
-
-        line = self._getInstance().currentLine
-        orig_pos = self._getInstance().getOriginalPos()
-        cur_pos = (vim.current.tabpage, vim.current.window, vim.current.buffer)
-
-        saved_eventignore = vim.options['eventignore']
-        vim.options['eventignore'] = 'BufLeave,WinEnter,BufEnter'
-        try:
-            vim.current.tabpage, vim.current.window, vim.current.buffer = orig_pos
-            self._acceptSelection(line)
-        finally:
-            vim.current.tabpage, vim.current.window, vim.current.buffer = cur_pos
-            vim.options['eventignore'] = saved_eventignore
-
     def _bangEnter(self):
         self._relocateCursor()
 

--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -213,7 +213,21 @@ class Manager(object):
         return False
 
     def _previewResult(self, preview):
-        pass
+        if not self._needPreview(preview):
+            return
+
+        line = self._getInstance().currentLine
+        orig_pos = self._getInstance().getOriginalPos()
+        cur_pos = (vim.current.tabpage, vim.current.window, vim.current.buffer)
+
+        saved_eventignore = vim.options['eventignore']
+        vim.options['eventignore'] = 'BufLeave,WinEnter,BufEnter'
+        try:
+            vim.current.tabpage, vim.current.window, vim.current.buffer = orig_pos
+            self._acceptSelection(line)
+        finally:
+            vim.current.tabpage, vim.current.window, vim.current.buffer = cur_pos
+            vim.options['eventignore'] = saved_eventignore
 
     def _restoreOrigCwd(self):
         pass


### PR DESCRIPTION
the option of  
   let g:Lf_PreviewResult = {
            \ 'File': 0,
            \ 'Buffer': 0,
            \ 'Mru': 0,
            \ 'Tag': 0,
            \ 'BufTag': 0,
            \ 'Function': 1,
            **\ 'Line': 1,**
            \ 'Colorscheme': 0
            \}
of LIne does not work, and I suppose a number of peoples need to preview the line when searching lines. so I chaged the code of  `line` only.