### PR TITLE
add ctags function expl options

### DIFF
--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -128,6 +128,7 @@ call s:InitDict('g:Lf_PreviewResult', {
             \})
 call s:InitDict('g:Lf_NormalMap', {})
 call s:InitVar('g:Lf_Extensions', {})
+call s:InitDict('g:Lf_CtagsFuncOpts', {})
 
 let s:Lf_CommandMap = {
             \ '<C-A>':         ['<C-A>'],

--- a/autoload/leaderf/python/leaderf/functionExpl.py
+++ b/autoload/leaderf/python/leaderf/functionExpl.py
@@ -52,6 +52,9 @@ class FunctionExplorer(Explorer):
                 "rust": "--rust-kinds=fPM",  # universal ctags
                 "ocaml": "--ocaml-kinds=mf",   # universal ctags
                 }
+        ctags_opts = lfEval('g:Lf_CtagsFuncOpts')
+        for k, v in ctags_opts.items():
+            self._ctags_options[k] = v
 
     def getContent(self, *args, **kwargs):
         if "--all" in kwargs.get("arguments", {}): # all buffers

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -356,6 +356,14 @@ g:Lf_Ctags                                      *g:Lf_Ctags*
 <
     Default value is "ctags".
 
+g:Lf_CtagsFuncOpts                              *g:Lf_CtagsFuncOpts*
+    Use this option to specify the options of ctags to generate the tags of
+    functions. e.g., >
+    let g:Lf_CtagsFuncOpts = {
+            \ 'c': '--c-kinds=fp',
+            \ 'rust': '--rust-kinds=f',
+            \ }
+<
 g:Lf_PreviewCode                                *g:Lf_PreviewCode*
     Use this option to specify whether to show the preview of the code the tag
     locates in when navigating the tags.


### PR DESCRIPTION
添加一个 `g:Lf_CtagsFuncOpts` 选项，让用户可以自定义使用 `LeaderfFunction` 时的 `ctags` 选项