### PR TITLE
Allow LeaderF to work with Git submodules

### DIFF
--- a/autoload/leaderf/python/leaderf/fileExpl.py
+++ b/autoload/leaderf/python/leaderf/fileExpl.py
@@ -225,7 +225,7 @@ class FileExplorer(Explorer):
                     ignore += ' -x "%s"' % i
                 for i in wildignore["file"]:
                     ignore += ' -x "%s"' % i
-                cmd = "git ls-files && git ls-files --others --exclude-standard %s" % ignore
+                cmd = "git ls-files --recurse-submodules && git ls-files --others --exclude-standard %s" % ignore
                 self._external_cmd = cmd
                 return cmd
             elif self._exists(dir, ".hg"):


### PR DESCRIPTION
One of the projects I work in regularly has a couple of submodules, and the default LeaderF implementation does not show the files in these submodules. This change fixes this with no negative impact on projects that do not have submodules.