### PR TITLE
add one-dark colorscheme for leaderF

### DIFF
--- a/autoload/leaderf/colorscheme/one.vim
+++ b/autoload/leaderf/colorscheme/one.vim
@@ -1,0 +1,104 @@
+" ============================================================================
+" File:        one.vim
+" Description:
+" Author:      Tomwei7 <tomwei7@163.com>
+" Website:     https://github.com/tomwei7
+" Note:
+" License:     Apache License, Version 2.0
+" ============================================================================
+
+
+let s:palette = {
+            \   'stlName': {
+            \       'gui': 'bold',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#98C379',
+            \       'cterm': 'bold',
+            \       'ctermfg': '16',
+            \       'ctermbg': '76'
+            \   },
+            \   'stlCategory': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#E06C75',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '16',
+            \       'ctermbg': '168'
+            \   },
+            \   'stlNameOnlyMode': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#61AFEF',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '16',
+            \       'ctermbg': '75'
+            \   },
+            \   'stlFullPathMode': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#61AFEF',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '16',
+            \       'ctermbg': '147'
+            \   },
+            \   'stlFuzzyMode': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#E5C07B',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '16',
+            \       'ctermbg': '180'
+            \   },
+            \   'stlRegexMode': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#98C379',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '16',
+            \       'ctermbg': '76'
+            \   },
+            \   'stlCwd': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#ABB2BF',
+            \       'guibg': '#475265',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '145',
+            \       'ctermbg': '236'
+            \   },
+            \   'stlBlank': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#ABB2BF',
+            \       'guibg': '#3E4452',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '145',
+            \       'ctermbg': '235'
+            \   },
+            \   'stlLineInfo': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#98C379',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '16',
+            \       'ctermbg': '76'
+            \   },
+            \   'stlTotal': {
+            \       'gui': 'NONE',
+            \       'font': 'NONE',
+            \       'guifg': '#3E4452',
+            \       'guibg': '#98C379',
+            \       'cterm': 'NONE',
+            \       'ctermfg': '16',
+            \       'ctermbg': '76'
+            \   }
+            \ }
+
+let g:leaderf#colorscheme#default#palette = leaderf#colorscheme#mergePalette(s:palette)


### PR DESCRIPTION
Hi, i added one-dark colorscheme for leaderF inspired by [lightline.vim](https://github.com/itchyny/lightline.vim) one-dark colorscheme

![image](https://user-images.githubusercontent.com/4957677/46779049-e9e15c00-cd48-11e8-9834-7be8ada8dd8b.png)
