### PR TITLE
Add option g:Lf_WorkingDirectory to set working directory by user.

### DIFF
--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -110,6 +110,7 @@ call s:InitVar('g:Lf_RememberLastSearch', 0)
 call s:InitVar('g:Lf_UseCache', 1)
 call s:InitVar('g:Lf_RootMarkers', ['.git', '.hg', '.svn'])
 call s:InitVar('g:Lf_WorkingDirectoryMode', 'c')
+call s:InitVar('g:Lf_WorkingDirectory', '')
 call s:InitVar('g:Lf_ShowHidden', 0)
 call s:InitDict('g:Lf_PreviewResult', {
             \ 'File': 0,

--- a/autoload/leaderf/python/leaderf/fileExpl.py
+++ b/autoload/leaderf/python/leaderf/fileExpl.py
@@ -676,12 +676,18 @@ class FileExplManager(Manager):
         self._orig_cwd = os.getcwd()
         root_markers = lfEval("g:Lf_RootMarkers")
         mode = lfEval("g:Lf_WorkingDirectoryMode")
+        working_dir = lfEval("g:Lf_WorkingDirectory")
 
         # https://github.com/neovim/neovim/issues/8336
         if lfEval("has('nvim')") == '1':
             chdir = vim.chdir
         else:
             chdir = os.chdir
+
+        if os.path.exists(working_dir) and os.path.isdir(working_dir):
+            chdir(working_dir)
+            super(FileExplManager, self).startExplorer(win_pos, *args, **kwargs)
+            return
 
         cur_buf_name = lfDecode(vim.current.buffer.name)
         fall_back = False

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -481,6 +481,12 @@ g:Lf_WorkingDirectoryMode                       *g:Lf_WorkingDirectoryMode*
     Note: if "f", "F" is included with "a" or "A", use the behavior of "f" or
     "F"(as a fallback) when a root can't be found.
 
+g:Lf_WorkingDirectory                           *g:Lf_WorkingDirectory*
+    Set LeaderF's working directory. It's will ignore |g:Lf_RootMarkers| and
+	|g:Lf_WorkingDirectoryMode| what you set.
+	e.g., >
+	let g:Lf_WorkingDirectory = finddir('.git', '.;')
+<
 g:Lf_CommandMap                                 *g:Lf_CommandMap*
     Use this option to customize the mappings inside LeaderF's
     prompt(|leaderf-prompt|).


### PR DESCRIPTION
支持用户设置工作目录，原因有两个：
1. 多个插件都各自搜索了一次工作目录，工作重复了，比如： https://github.com/jsfaint/gen_tags.vim/pull/77

2. 我想实现 farthestAncestor，又得另一个插件也要实现一遍，还不如在自己的 vimrc 里实现，然后传给插件。所以我把提交给 jsfaint/gen_tags.vim 的支持 farthestAncestor 合并请求关了，我会再去提交一个跟这个合并请求类似的。

比如：我把工程目录传给 vim-grepper 是这样的：
```
let g:grepper.ag.grepprg = 'ag --vimgrep $* '.g:root_dir
```
传给 LeaderF 是这样的：
```
let g:Lf_WorkingDirectory = g:root_dir
```