### PR TITLE
Add rg option --type-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ usage: Leaderf[!] rg [-h] [-e <PATTERN>...] [-F] [-i] [-L] [-P] [-S] [-s] [-v]
                      [--no-ignore-vcs] [-E <ENCODING>] [-M <NUM>] [-m <NUM>]
                      [--max-depth <NUM>] [--max-filesize <NUM+SUFFIX?>]
                      [-g <GLOB>...] [--iglob <GLOB>...]
-                     [--ignore-file <PATH>...] [-t <TYPE>...] [-T <TYPE>...]
+                     [--ignore-file <PATH>...] [--type-add <TYPE_SPEC>...]
+                     [-t <TYPE>...] [-T <TYPE>...]
                      [--current-buffer | --all-buffers] [--recall] [--append]
                      [--reverse] [--stayOpen] [--input <INPUT> | --cword]
                      [--top | --bottom | --left | --right | --belowright | --aboveleft | --fullScreen]
@@ -189,6 +190,8 @@ specific arguments:
                         Globs are matched case insensitively.(This option can be provided multiple times.)
   --ignore-file <PATH>...
                         Specifies a path to one or more .gitignore format rules files.
+  --type-add <TYPE_SPEC>...
+                        Add a new glob for a particular file type.
   -t <TYPE>..., --type <TYPE>...
                         Only search files matching TYPE. Multiple type flags may be provided.
   -T <TYPE>..., --type-not <TYPE>...

--- a/autoload/leaderf/Any.vim
+++ b/autoload/leaderf/Any.vim
@@ -110,6 +110,8 @@ let g:Lf_Arguments = {
             \               "help": "Include or exclude files and directories for searching that match the given glob. Globs are matched case insensitively.(This option can be provided multiple times.)"},
             \           {"name": ["--ignore-file"], "action": "append", "metavar": "<PATH>...",
             \               "help": "Specifies a path to one or more .gitignore format rules files."},
+            \           {"name": ["--type-add"], "action": "append", "metavar": "<TYPE_SPEC>...",
+            \               "help": "Add a new glob for a particular file type."},
             \           {"name": ["-t", "--type"], "action": "append", "metavar": "<TYPE>...",
             \               "help": "Only search files matching TYPE. Multiple type flags may be provided."},
             \           {"name": ["-T", "--type-not"], "action": "append", "metavar": "<TYPE>...",

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -99,7 +99,7 @@ class RgExplorer(Explorer):
         if "--ignore-file" in kwargs.get("arguments", {}):
             repeatable_options += "--ignore-file %s " % " --ignore-file ".join(kwargs.get("arguments", {})["--ignore-file"])
         if "--type-add" in kwargs.get("arguments", {}):
-            repeatable_options += "--type-add %s " % kwargs.get("arguments", {})["--type-add"][0]
+            repeatable_options += "--type-add %s " % " --type-add ".join(kwargs.get("arguments", {})["--type-add"])
         if "-t" in kwargs.get("arguments", {}):
             repeatable_options += "-t %s " % " -t ".join(kwargs.get("arguments", {})["-t"])
         if "-T" in kwargs.get("arguments", {}):

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -98,6 +98,8 @@ class RgExplorer(Explorer):
             repeatable_options += "--iglob %s " % " --iglob ".join(kwargs.get("arguments", {})["--iglob"])
         if "--ignore-file" in kwargs.get("arguments", {}):
             repeatable_options += "--ignore-file %s " % " --ignore-file ".join(kwargs.get("arguments", {})["--ignore-file"])
+        if "--type-add" in kwargs.get("arguments", {}):
+            repeatable_options += "--type-add %s " % kwargs.get("arguments", {})["--type-add"][0]
         if "-t" in kwargs.get("arguments", {}):
             repeatable_options += "-t %s " % " -t ".join(kwargs.get("arguments", {})["-t"])
         if "-T" in kwargs.get("arguments", {}):


### PR DESCRIPTION
通过 `--type-add` 可以设置自定义的文件类型

```viml
xnoremap gs :<C-U><C-R>=printf("Leaderf! rg -F --type-add 'decl:*.decl' -t decl -t c -t py -t lua --nowrap --stayOpen -e %s ", leaderf#Rg#visual())<cr><cr>
```