### PR TITLE
Update gtagsExpl.py

### DIFF
--- a/autoload/leaderf/python/leaderf/gtagsExpl.py
+++ b/autoload/leaderf/python/leaderf/gtagsExpl.py
@@ -455,10 +455,10 @@ class GtagsExplorer(Explorer):
 
         root, dbpath, exists = self._root_dbpath(filename)
         if not filename.startswith(root):
-            if self._has_nvim:
-                vim.async_call(lfCmd, "let g:Lf_Debug_Gtags = '%s'" % escQuote(str((filename, root))))
-            else:
-                lfCmd("let g:Lf_Debug_Gtags = '%s'" % escQuote(str((filename, root))))
+            # if self._has_nvim:
+            #     vim.async_call(lfCmd, "let g:Lf_Debug_Gtags = '%s'" % escQuote(str((filename, root))))
+            # else:
+            #     lfCmd("let g:Lf_Debug_Gtags = '%s'" % escQuote(str((filename, root))))
 
             return
 


### PR DESCRIPTION
LeaderF/autoload/leaderf/python/leaderf/gtagsExpl.py :
lines: 458 - 461请直接注释,   在Python线程里访问vim的变量了，导致cash.
fixed issue: #430