### PR TITLE
New option `g:Lf_HistoryExclude` to delete `:LeaderfHistory*` records

### DIFF
--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -89,6 +89,10 @@ call s:InitVar('g:Lf_MruWildIgnore', {
             \ 'dir': [],
             \ 'file': []
             \})
+call s:InitVar('g:Lf_HistoryExclude', {
+            \ 'cmd': [],
+            \ 'search': []
+            \})
 if &encoding ==? "utf-8"
     call s:InitVar('g:Lf_StlSeparator', {
                 \ 'left': '►',

--- a/autoload/leaderf/python/leaderf/historyExpl.py
+++ b/autoload/leaderf/python/leaderf/historyExpl.py
@@ -18,15 +18,19 @@ class HistoryExplorer(Explorer):
 
     def getContent(self, *args, **kwargs):
         result_list = []
+        pattern_exclude = []
+        history_pattern_exclude = lfEval("g:Lf_HistoryExclude")
         if "history" in kwargs:
             lfCmd("let tmp = @x")
             lfCmd("redir @x")
             if kwargs.get("history") == "cmd":
                 self._history_type = "Cmd_History"
                 lfCmd("silent history :")
+                pattern_exclude = history_pattern_exclude.get('cmd', [])
             elif kwargs.get("history") == "search":
                 self._history_type = "Search_History"
                 lfCmd("silent history /")
+                pattern_exclude = history_pattern_exclude.get('search', [])
             else:
                 self._history_type = "History"
                 lfCmd("let @x = ''")
@@ -35,6 +39,9 @@ class HistoryExplorer(Explorer):
             lfCmd("redir END")
             result_list = result.splitlines()[2:]
             result_list = [line[1:].lstrip().split('  ', 1)[1] for line in result_list]
+
+            compiled = [re.compile(p) for p in pattern_exclude]
+            result_list = [line for line in result_list if all(p.search(line) is None for p in compiled)]
 
         return result_list[::-1]
 

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -545,7 +545,6 @@ g:Lf_HistoryExclude                              *g:Lf_HistoryExclude*
             \ 'search': []
             \}
 <
-
     This is specified with a Python regular expression.
 <
     For example, you can set as below: >

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -535,6 +535,26 @@ g:Lf_HistoryNumber                              *g:Lf_HistoryNumber*
     Specify the number of records in history.
     Default value is 100.
 
+g:Lf_HistoryExclude                              *g:Lf_HistoryExclude*
+    This option indicates that do not display the historires that matches the
+    patterns defined in it.
+
+    Default value is: >
+    let g:Lf_HistoryExclude = {
+            \ 'cmd': [],
+            \ 'search': []
+            \}
+<
+
+    This is specified with a Python regular expression.
+<
+    For example, you can set as below: >
+    let g:Lf_HistoryExclude = {
+            \ 'cmd': ['^w!?', '^q!?', '^.\s*$'],
+            \ 'search': ['^Plug']
+            \}
+<
+
 g:Lf_RgConfig                                   *g:Lf_RgConfig*
     Specify a list of ripgrep configurations. For example, >
     let g:Lf_RgConfig = [


### PR DESCRIPTION
I'd like to add an option that allows you to delete `:LeaderfHistory*` records using regular expressions.

I wanted to do the same because I deleted the line from the command line window as follows:

```vim
autocmd MyAutoCmd CmdwinEnter : silent g/\v^wq?!?/"_d
```

Thank you for your consideration.

Usage

```vim
let g:Lf_HistoryExclude = {
\   'cmd': ['^w!?', '^q!?', '^.\s*$'],
\   'search': ['^Plug']
\}
```