### PR TITLE
Added a command to edit history entry.

### DIFF
--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -135,6 +135,7 @@ call s:InitDict('g:Lf_GtagsfilesCmd', {
             \ '.hg': 'hg files',
             \ 'default': 'rg --no-messages --files'
             \})
+call s:InitVar('g:Lf_HistoryEditPromptIfEmpty', 1)
 
 let s:Lf_CommandMap = {
             \ '<C-A>':         ['<C-A>'],

--- a/autoload/leaderf/Cmd_History.vim
+++ b/autoload/leaderf/Cmd_History.vim
@@ -1,0 +1,16 @@
+" ============================================================================
+" File:        Cmd_History.vim
+" Description:
+" Author:      tamago324 <tamago_pad@yahoo.co.jp>
+" Website:     https://github.com/tamago324
+" Note:
+" License:     Apache License, Version 2.0
+" ============================================================================
+
+if leaderf#versionCheck() == 0  " this check is necessary
+    finish
+endif
+
+function! leaderf#Cmd_History#NormalModeFilter(winid, key) abort
+    return leaderf#History#NormalModeFilter(a:winid, a:key)
+endfunction

--- a/autoload/leaderf/History.vim
+++ b/autoload/leaderf/History.vim
@@ -20,6 +20,7 @@ function! leaderf#History#Maps()
     " nnoremap <buffer> <silent> <Esc>         :exec g:Lf_py "historyExplManager.quit()"<CR>
     nnoremap <buffer> <silent> <C-I>         :exec g:Lf_py "historyExplManager.input()"<CR>
     nnoremap <buffer> <silent> e             :exec g:Lf_py "historyExplManager.editHistory()"<CR>
+    nnoremap <buffer> <silent> <F1>          :exec g:Lf_py "historyExplManager.toggleHelp()"<CR>
     if has_key(g:Lf_NormalMap, "History")
         for i in g:Lf_NormalMap["History"]
             exec 'nnoremap <buffer> <silent> '.i[0].' '.i[1]
@@ -97,6 +98,8 @@ function! leaderf#History#NormalModeFilter(winid, key) abort
         exec g:Lf_py "historyExplManager.input()"
     elseif key ==# "o" || key ==? "<CR>" || key ==? "<2-LeftMouse>"
         exec g:Lf_py "historyExplManager.accept()"
+    elseif key ==? "<F1>"
+        exec g:Lf_py "historyExplManager.toggleHelp()"
     elseif key ==? "e"
         exec g:Lf_py "historyExplManager.editHistory()"
     endif

--- a/autoload/leaderf/History.vim
+++ b/autoload/leaderf/History.vim
@@ -19,9 +19,87 @@ function! leaderf#History#Maps()
     nnoremap <buffer> <silent> q             :exec g:Lf_py "historyExplManager.quit()"<CR>
     " nnoremap <buffer> <silent> <Esc>         :exec g:Lf_py "historyExplManager.quit()"<CR>
     nnoremap <buffer> <silent> <C-I>         :exec g:Lf_py "historyExplManager.input()"<CR>
+    nnoremap <buffer> <silent> e             :exec g:Lf_py "historyExplManager.editHistory()"<CR>
     if has_key(g:Lf_NormalMap, "History")
         for i in g:Lf_NormalMap["History"]
             exec 'nnoremap <buffer> <silent> '.i[0].' '.i[1]
         endfor
     endif
+endfunction
+
+function! leaderf#History#NormalModeFilter(winid, key) abort
+    let key = get(g:Lf_KeyDict, get(g:Lf_KeyMap, a:key, a:key), a:key)
+
+    if key !=# "g"
+        call win_execute(a:winid, "let g:Lf_History_is_g_pressed = 0")
+    endif
+
+    if key ==# "j" || key ==? "<Down>"
+        call win_execute(a:winid, "norm! j")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "historyExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==# "k" || key ==? "<Up>"
+        call win_execute(a:winid, "norm! k")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "historyExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==? "<PageUp>" || key ==? "<C-B>"
+        call win_execute(a:winid, "norm! \<PageUp>")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        exec g:Lf_py "historyExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==? "<PageDown>" || key ==? "<C-F>"
+        call win_execute(a:winid, "norm! \<PageDown>")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        exec g:Lf_py "historyExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==# "g"
+        if get(g:, "Lf_History_is_g_pressed", 0) == 0
+            let g:Lf_History_is_g_pressed = 1
+        else
+            let g:Lf_History_is_g_pressed = 0
+            call win_execute(a:winid, "norm! gg")
+            exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+            redraw
+        endif
+    elseif key ==# "G"
+        call win_execute(a:winid, "norm! G")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        redraw
+    elseif key ==? "<C-U>"
+        call win_execute(a:winid, "norm! \<C-U>")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        redraw
+    elseif key ==? "<C-D>"
+        call win_execute(a:winid, "norm! \<C-D>")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        redraw
+    elseif key ==? "<LeftMouse>"
+        if has('patch-8.1.2266')
+            call win_execute(a:winid, "exec v:mouse_lnum")
+            call win_execute(a:winid, "exec 'norm!'.v:mouse_col.'|'")
+            exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+            redraw
+        endif
+    elseif key ==? "<ScrollWheelUp>"
+        call win_execute(a:winid, "norm! 3k")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "historyExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==? "<ScrollWheelDown>"
+        call win_execute(a:winid, "norm! 3j")
+        exec g:Lf_py "historyExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "historyExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==# "q" || key ==? "<ESC>"
+        exec g:Lf_py "historyExplManager.quit()"
+    elseif key ==# "i" || key ==? "<Tab>"
+        call leaderf#ResetPopupOptions(a:winid, 'filter', 'leaderf#PopupFilter')
+        exec g:Lf_py "historyExplManager.input()"
+    elseif key ==# "o" || key ==? "<CR>" || key ==? "<2-LeftMouse>"
+        exec g:Lf_py "historyExplManager.accept()"
+    elseif key ==? "e"
+        exec g:Lf_py "historyExplManager.editHistory()"
+    endif
+
+    return 1
 endfunction

--- a/autoload/leaderf/Search_History.vim
+++ b/autoload/leaderf/Search_History.vim
@@ -1,0 +1,16 @@
+" ============================================================================
+" File:        Cmd_History.vim
+" Description:
+" Author:      tamago324 <tamago_pad@yahoo.co.jp>
+" Website:     https://github.com/tamago324
+" Note:
+" License:     Apache License, Version 2.0
+" ============================================================================
+
+if leaderf#versionCheck() == 0  " this check is necessary
+    finish
+endif
+
+function! leaderf#Search_History#NormalModeFilter(winid, key) abort
+    return leaderf#History#NormalModeFilter(a:winid, a:key)
+endfunction

--- a/autoload/leaderf/python/leaderf/historyExpl.py
+++ b/autoload/leaderf/python/leaderf/historyExpl.py
@@ -118,9 +118,8 @@ class HistoryExplManager(Manager):
         instance = self._getInstance()
 
         line = instance.currentLine
-        # XXX: option で空の場合、プロンプトの入力値を持ってくるかどうかを選択
-        if len(line.strip()) == 0:
-            # instance.getPopupInstance().input_win().
+        edit_prompt = lfEval("g:Lf_HistoryEditPromptIfEmpty") == "1"
+        if edit_prompt and len(line.strip()) == 0:
             line = instance._cli.pattern
 
         instance.exitBuffer()

--- a/autoload/leaderf/python/leaderf/historyExpl.py
+++ b/autoload/leaderf/python/leaderf/historyExpl.py
@@ -104,6 +104,23 @@ class HistoryExplManager(Manager):
         """
         return 0
 
+    def editHistory(self):
+        instance = self._getInstance()
+
+        line = instance.currentLine
+        # XXX: option で空の場合、プロンプトの入力値を持ってくるかどうかを選択
+        if len(line.strip()) == 0:
+            # instance.getPopupInstance().input_win().
+            line = instance._cli.pattern
+
+        instance.exitBuffer()
+        cmd = ":"
+
+        if self._getExplorer().getHistoryType() == "Search_History":
+            cmd = "/"
+
+        lfCmd("call feedkeys('%s')" % (cmd + escQuote(line)))
+
 
 #*****************************************************
 # historyExplManager is a singleton

--- a/autoload/leaderf/python/leaderf/historyExpl.py
+++ b/autoload/leaderf/python/leaderf/historyExpl.py
@@ -114,6 +114,11 @@ class HistoryExplManager(Manager):
         help.append('" ---------------------------------------------------------')
         return help
 
+    def _cmdExtension(self, cmd):
+        if equal(cmd, '<C-o>'):
+            self.editHistory()
+        return True
+
     def editHistory(self):
         instance = self._getInstance()
 

--- a/autoload/leaderf/python/leaderf/historyExpl.py
+++ b/autoload/leaderf/python/leaderf/historyExpl.py
@@ -104,6 +104,16 @@ class HistoryExplManager(Manager):
         """
         return 0
 
+    def _createHelp(self):
+        help = []
+        help.append('" <CR>/<double-click>/o : open file under cursor')
+        help.append('" i/<Tab> : switch to input mode')
+        help.append('" q : quit')
+        help.append('" e : edit command under cursor')
+        help.append('" <F1> : toggle this help')
+        help.append('" ---------------------------------------------------------')
+        return help
+
     def editHistory(self):
         instance = self._getInstance()
 

--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -53,8 +53,6 @@ else:
 def modifiableController(func):
     @wraps(func)
     def deco(self, *args, **kwargs):
-        if self._getExplorer().getStlCategory() in ("Search_History", "Cmd_History"):
-            return func(self, *args, **kwargs)
         self._getInstance().buffer.options['modifiable'] = True
         func(self, *args, **kwargs)
         self._getInstance().buffer.options['modifiable'] = False
@@ -728,8 +726,6 @@ class Manager(object):
         return self._instance
 
     def _createHelpHint(self):
-        if self._getExplorer().getStlCategory() in ("Search_History", "Cmd_History"):
-            return
         help = []
         if not self._show_help:
             if lfEval("get(g:, 'Lf_HideHelp', 0)") == '0':

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -553,6 +553,12 @@ g:Lf_HistoryExclude                              *g:Lf_HistoryExclude*
             \ 'search': ['^Plug']
             \}
 <
+g:Lf_HistoryEditPromptIfEmpty                   *g:Lf_HistoryEditPromptIfEmpty*
+    This option is used when the history (cmdHistory or searchHistory).
+    If set to 1, when editing is started when there are 0 results, the text of
+    the entered prompt is edited.
+    Default value is 1.
+
 g:Lf_RgConfig                                   *g:Lf_RgConfig*
     Specify a list of ripgrep configurations. For example, >
     let g:Lf_RgConfig = [

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -910,6 +910,10 @@ Once LeaderF is launched:                       *prompt* *leaderf-prompt*
     <C-P> : preview the result.
     <C-Up> : scroll up in the popup preview window.
     <C-Down> : scroll down in the popup preview window.
+
+    cmdHistory/searchHistory only mappings:
+        <C-o> : edit command under cursor.
+
 ==============================================================================
 FAQ                                             *leaderf-faq*
 


### PR DESCRIPTION
Hi.

I implemented a command that can edit the command.

* Added help (`F1`) in normal mode.
* Added insert mode mappings.
* Added popup window (float window) mappings.
* Added new option `g:Lf_HistoryEditPromptIfEmpty`

Because the function of `leaderf#*#NormalModeFilter()` was called in `StlCategory`, the files were split into `Cmd_History.vim` and `Search_History.vim`. However, since the mapping is the same, we call `leaderf#History#NormalModeFilter()`.

Prompts for editing are not prepared on their own, but use the prompts of Vim. This is because input completion is effective and incremental search can be performed.

~What I couldn't do was start editing in insert mode. Does this have to give up?~
Could be implemented using `_cmdExtension()`.


Please give me a review when you have time.

Thank you!

This pull request related to #423
