### PR TITLE
Add command LeaderfCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ usage: Leaderf[!] [-h] [--reverse] [--stayOpen] [--input <INPUT> | --cword]
                   [--nameOnly | --fullPath | --fuzzy | --regexMode] [--nowrap] [--next | --previous]
                   [--recall] [--popup-height <POPUP_HEIGHT>] [--popup-width <POPUP_WIDTH>]
                   
-                  {file,tag,function,mru,searchHistory,cmdHistory,help,line,colorscheme,gtags,self,bufTag,buffer,rg}
+                  {file,tag,function,mru,searchHistory,cmdHistory,help,line,colorscheme,gtags,self,bufTag,buffer,rg,filetype,command}
                   ...
 
 optional arguments:
@@ -125,7 +125,7 @@ optional arguments:
 
 subcommands:
 
-  {file,tag,function,mru,searchHistory,cmdHistory,help,line,colorscheme,gtags,self,bufTag,buffer,rg,filetype}
+  {file,tag,function,mru,searchHistory,cmdHistory,help,line,colorscheme,gtags,self,bufTag,buffer,rg,filetype,command}
     file                search files
     tag                 navigate tags using the tags file
     function            navigate functions or methods in the buffer
@@ -141,6 +141,7 @@ subcommands:
     buffer              search buffers
     rg                  grep using rg
     filetype            navigate the filetype
+    command             execute built-in/user-defined Ex commands.
 
 If [!] is given, enter normal mode directly.
 ```

--- a/autoload/leaderf/Any.vim
+++ b/autoload/leaderf/Any.vim
@@ -50,6 +50,7 @@ let g:Lf_Helps = {
             \ "rg":             "grep using rg",
             \ "gtags":          "navigate tags using the gtags",
             \ "filetype":       "navigate the filetype",
+            \ "command":        "execute built-in/user-defined Ex commands",
             \ }
 
 let g:Lf_Arguments = {
@@ -173,6 +174,7 @@ let g:Lf_Arguments = {
             \           {"name": ["--auto-jump"], "nargs": "?", "metavar": "<TYPE>", "help": "Jump to the tag directly when there is only one match. <TYPE> can be 'h', 'v' or 't', which mean jump to a horizontally, vertically split window, or a new tabpage respectively. If <TYPE> is omitted, jump to a position in current window."},
             \   ],
             \ "filetype": [],
+            \ "command": [],
             \}
 
 let g:Lf_CommonArguments = [

--- a/autoload/leaderf/Command.vim
+++ b/autoload/leaderf/Command.vim
@@ -1,0 +1,109 @@
+" ============================================================================
+" File:        Command.vim
+" Description:
+" Author:      tamago324 <tamago_pad@yahoo.co.jp>
+" Website:     https://github.com/tamago324
+" Note:
+" License:     Apache License, Version 2.0
+" ============================================================================
+
+if leaderf#versionCheck() == 0
+    finish
+endif
+
+exec g:Lf_py "from leaderf.commandExpl import *"
+
+function! leaderf#Command#Maps()
+    nmapclear <buffer>
+    nnoremap <buffer> <silent> <CR>          :exec g:Lf_py "commandExplManager.accept()"<CR>
+    nnoremap <buffer> <silent> o             :exec g:Lf_py "commandExplManager.accept()"<CR>
+    nnoremap <buffer> <silent> <2-LeftMouse> :exec g:Lf_py "commandExplManager.accept()"<CR>
+    nnoremap <buffer> <silent> q             :exec g:Lf_py "commandExplManager.quit()"<CR>
+    nnoremap <buffer> <silent> <C-I>         :exec g:Lf_pI "commandExplManager.input()"<CR>
+    nnoremap <buffer> <silent> e             :exec g:Lf_py "commandExplManager.editCommand()"<CR>
+    nnoremap <buffer> <silent> <F1>          :exec g:Lf_py "commandExplManager.toggleHelp()"<CR>
+    if has_key(g:Lf_NormalMap, "Command")
+        for i in g:Lf_NormalMap["Command"]
+            exec 'nnoremap <buffer> <silent> '.i[0].' '.i[1]
+        endfor
+    endif
+endfunction
+
+function! leaderf#Command#NormalModeFilter(winid, key) abort
+    let key = get(g:Lf_KeyDict, get(g:Lf_KeyMap, a:key, a:key), a:key)
+
+    if key !=# "g"
+        call win_execute(a:winid, "let g:Lf_Command_is_g_pressed = 0")
+    endif
+
+    if key ==# "j" || key ==? "<Down>"
+        call win_execute(a:winid, "norm! j")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "commandExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==# "k" || key ==? "<Up>"
+        call win_execute(a:winid, "norm! k")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "commandExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==? "<PageUp>" || key ==? "<C-B>"
+        call win_execute(a:winid, "norm! \<PageUp>")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        exec g:Lf_py "commandExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==? "<PageDown>" || key ==? "<C-F>"
+        call win_execute(a:winid, "norm! \<PageDown>")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        exec g:Lf_py "commandExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==# "g"
+        if get(g:, "Lf_Command_is_g_pressed", 0) == 0
+            let g:Lf_Command_is_g_pressed = 1
+        else
+            let g:Lf_Command_is_g_pressed = 0
+            call win_execute(a:winid, "norm! gg")
+            exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+            redraw
+        endif
+    elseif key ==# "G"
+        call win_execute(a:winid, "norm! G")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        redraw
+    elseif key ==? "<C-U>"
+        call win_execute(a:winid, "norm! \<C-U>")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        redraw
+    elseif key ==? "<C-D>"
+        call win_execute(a:winid, "norm! \<C-D>")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        redraw
+    elseif key ==? "<LeftMouse>"
+        if has('patch-8.1.2266')
+            call win_execute(a:winid, "exec v:mouse_lnum")
+            call win_execute(a:winid, "exec 'norm!'.v:mouse_col.'|'")
+            exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+            redraw
+        endif
+    elseif key ==? "<ScrollWheelUp>"
+        call win_execute(a:winid, "norm! 3k")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "commandExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==? "<ScrollWheelDown>"
+        call win_execute(a:winid, "norm! 3j")
+        exec g:Lf_py "commandExplManager._cli._buildPopupPrompt()"
+        redraw
+        exec g:Lf_py "commandExplManager._getInstance().refreshPopupStatusline()"
+    elseif key ==# "q" || key ==? "<ESC>"
+        exec g:Lf_py "commandExplManager.quit()"
+    elseif key ==# "i" || key ==? "<Tab>"
+        call leaderf#ResetPopupOptions(a:winid, 'filter', 'leaderf#PopupFilter')
+        exec g:Lf_py "commandExplManager.input()"
+    elseif key ==# "o" || key ==? "<CR>" || key ==? "<2-LeftMouse>"
+        exec g:Lf_py "commandExplManager.accept()"
+    elseif key ==? "<F1>"
+        exec g:Lf_py "commandExplManager.toggleHelp()"
+    elseif key ==? "e"
+        exec g:Lf_py "commandExplManager.editCommand()"
+    endif
+
+    return 1
+endfunction

--- a/autoload/leaderf/python/leaderf/anyExpl.py
+++ b/autoload/leaderf/python/leaderf/anyExpl.py
@@ -686,6 +686,9 @@ class AnyHub(object):
             elif category == "filetype":
                 from .filetypeExpl import filetypeExplManager
                 manager = filetypeExplManager
+            elif category == "command":
+                from .commandExpl import commandExplManager
+                manager = commandExplManager
             else:
                 import ctypes
                 manager_id = lfFunction(lfEval("g:Lf_PythonExtensions['%s'].manager_id" % category))()

--- a/autoload/leaderf/python/leaderf/commandExpl.py
+++ b/autoload/leaderf/python/leaderf/commandExpl.py
@@ -48,7 +48,7 @@ class CommandExplorer(Explorer):
                 result_list.append(match.group(1))
 
         # built-in Ex commands
-        index_file = lfEval("globpath(&rtp, '*/index.txt')")
+        index_file = lfEval("$VIMRUNTIME/doc/index.txt")
         with lfOpen(index_file, 'r', errors="ignore") as f:
             for line in f:
                 match = RE_BUILT_IN_COMMAND.search(line)

--- a/autoload/leaderf/python/leaderf/commandExpl.py
+++ b/autoload/leaderf/python/leaderf/commandExpl.py
@@ -33,14 +33,7 @@ class CommandExplorer(Explorer):
         result_list = []
 
         # user-defined Ex commands
-        lfCmd("let tmp = @x")
-        lfCmd("redir @x")
-        lfCmd("silent command")
-
-        result = lfEval("@x")
-
-        lfCmd("let @x = tmp")
-        lfCmd("redir END")
+        result = lfEval("execute('command')")
 
         for line in result.splitlines()[2:]:
             match = RE_USER_DEFINED_COMMAND.match(line)

--- a/autoload/leaderf/python/leaderf/commandExpl.py
+++ b/autoload/leaderf/python/leaderf/commandExpl.py
@@ -48,7 +48,7 @@ class CommandExplorer(Explorer):
                 result_list.append(match.group(1))
 
         # built-in Ex commands
-        index_file = lfEval("$VIMRUNTIME/doc/index.txt")
+        index_file = lfEval("expand('$VIMRUNTIME/doc/index.txt')")
         with lfOpen(index_file, 'r', errors="ignore") as f:
             for line in f:
                 match = RE_BUILT_IN_COMMAND.search(line)

--- a/autoload/leaderf/python/leaderf/commandExpl.py
+++ b/autoload/leaderf/python/leaderf/commandExpl.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import re
+from .utils import *
+from .explorer import *
+from .manager import *
+
+# :command result line
+# "!|  LeaderfBufTag     0      Leaderf<bang> bufTag"
+#      ^^^^^^^^^^^^^
+RE_USER_DEFINED_COMMAND = re.compile(r"^.{4}(\w+)")
+
+# index.txt line
+# "|:silent|	:sil[ent]	..."
+#    ^^^^^^
+RE_BUILT_IN_COMMAND = re.compile(r"^\|:([^|]+)\|")
+
+#*****************************************************
+# CommandExplorer
+#*****************************************************
+class CommandExplorer(Explorer):
+    def __init__(self):
+        self._content = []
+
+    def getContent(self, *args, **kwargs):
+        if self._content:
+            return self._content
+        else:
+            return self.getFreshContent()
+
+    def getFreshContent(self, *args, **kwargs):
+        result_list = []
+
+        # user-defined Ex commands
+        lfCmd("let tmp = @x")
+        lfCmd("redir @x")
+        lfCmd("silent command")
+
+        result = lfEval("@x")
+
+        lfCmd("let @x = tmp")
+        lfCmd("redir END")
+
+        for line in result.splitlines()[2:]:
+            match = RE_USER_DEFINED_COMMAND.match(line)
+            if match:
+                result_list.append(match.group(1))
+
+        # built-in Ex commands
+        index_file = lfEval("globpath(&rtp, '*/index.txt')")
+        with lfOpen(index_file, 'r', errors="ignore") as f:
+            for line in f:
+                match = RE_BUILT_IN_COMMAND.search(line)
+                if match:
+                    result_list.append(match.group(1))
+
+        return result_list
+
+    def getStlCategory(self):
+        return "Command"
+
+    def getStlCurDir(self):
+        return escQuote(lfEncode(os.getcwd()))
+
+
+# *****************************************************
+# CommandExplManager
+# *****************************************************
+class CommandExplManager(Manager):
+    def __init__(self):
+        super(CommandExplManager, self).__init__()
+
+    def _getExplClass(self):
+        return CommandExplorer
+
+    def _defineMaps(self):
+        lfCmd("call leaderf#Command#Maps()")
+
+    def _acceptSelection(self, *args, **kwargs):
+        """"""
+        cmd = args[0]
+        try:
+            lfCmd(cmd)
+        except vim.error as e:
+            error = lfEncode(str(repr(e)))
+            if "E471" in error:
+                # Arguments mandatory
+                lfCmd("call feedkeys(':%s ')" % escQuote(cmd))
+            else:
+                lfPrintError(e)
+
+    def _getDigest(self, line, mode):
+        return line
+
+    def _getDegestStartPos(self, line, mode):
+        return 0
+
+    def _createHelp(self):
+        help = []
+        help.append('" <CR>/o : execute command under cursor')
+        help.append('" q : quit')
+        help.append('" i : switch to input mode')
+        help.append('" e : edit command under cursor')
+        help.append('" <F1> : toggle this help')
+        help.append('" ---------------------------------------------------------')
+        return help
+
+    def _cmdExtension(self, cmd):
+        if equal(cmd, '<C-o>'):
+            self.editCommand()
+        return True
+
+    def editCommand(self):
+        instance = self._getInstance()
+        line = instance.currentLine
+        instance.exitBuffer()
+        lfCmd("call feedkeys(':%s')" % escQuote(line))
+
+
+# *****************************************************
+# commandExplManager is a singleton
+# *****************************************************
+commandExplManager = CommandExplManager()
+
+__all__ = ["commandExplManager"]

--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -1059,7 +1059,8 @@ class Manager(object):
                     filter_method = partial(fuzzyEngine.fuzzyMatchEx, engine=self._fuzzy_engine, pattern=pattern,
                                             is_name_only=False, sort_results=False)
                 elif self._getExplorer().getStlCategory() in ["Self", "Buffer", "Mru", "BufTag",
-                        "Function", "History", "Cmd_History", "Search_History", "Tag", "Rg", "Filetype"]:
+                        "Function", "History", "Cmd_History", "Search_History", "Tag", "Rg", "Filetype",
+                        "Command"]:
                     filter_method = partial(fuzzyEngine.fuzzyMatchEx, engine=self._fuzzy_engine, pattern=pattern,
                                             is_name_only=True, sort_results=False)
                 else:
@@ -1087,7 +1088,8 @@ class Manager(object):
                                             self._cli.isFullPath,
                                             fuzzy_match.getWeight2)
                 elif self._getExplorer().getStlCategory() in ["Self", "Buffer", "Mru", "BufTag",
-                        "Function", "History", "Cmd_History", "Search_History", "Tag", "Rg", "Filetype"]:
+                        "Function", "History", "Cmd_History", "Search_History", "Tag", "Rg", "Filetype",
+                        "Command"]:
                     filter_method = partial(self._fuzzyFilterEx,
                                             self._cli.isFullPath,
                                             fuzzy_match.getWeight3)
@@ -1224,7 +1226,8 @@ class Manager(object):
                         filter_method = partial(fuzzyEngine.fuzzyMatchEx, engine=self._fuzzy_engine, pattern=pattern,
                                                 is_name_only=True, sort_results=not is_continue)
                 elif self._getExplorer().getStlCategory() in ["Self", "Buffer", "Mru", "BufTag",
-                        "Function", "History", "Cmd_History", "Search_History", "Tag", "Filetype"]:
+                        "Function", "History", "Cmd_History", "Search_History", "Tag", "Filetype",
+                        "Command"]:
                     return_index = True
                     filter_method = partial(fuzzyEngine.fuzzyMatchEx, engine=self._fuzzy_engine, pattern=pattern,
                                             is_name_only=True, sort_results=not is_continue)
@@ -1255,7 +1258,8 @@ class Manager(object):
                                             self._cli.isFullPath,
                                             fuzzy_match.getWeight2)
                 elif self._getExplorer().getStlCategory() in ["Self", "Buffer", "Mru", "BufTag",
-                        "Function", "History", "Cmd_History", "Search_History", "Rg", "Filetype"]:
+                        "Function", "History", "Cmd_History", "Search_History", "Rg", "Filetype",
+                        "Command"]:
                     filter_method = partial(self._fuzzyFilter,
                                             self._cli.isFullPath,
                                             fuzzy_match.getWeight3)

--- a/autoload/leaderf/python/leaderf/selfExpl.py
+++ b/autoload/leaderf/python/leaderf/selfExpl.py
@@ -36,6 +36,7 @@ class SelfExplorer(Explorer):
             '17 LeaderfHelp             "navigate the help tags"',
             '18 LeaderfColorscheme      "switch between colorschemes"',
             '19 LeaderfFiletype         "navigate the filetype"',
+            '20 LeaderfCommand          "execute built-in/user-defined Ex commands"',
             ]
 
     def getContent(self, *args, **kwargs):

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -855,6 +855,9 @@ USAGE                                           *leaderf-usage*
 :LeaderfFiletype                                *LeaderfFiletype*
     Launch LeaderF to navigate the filetype.
 
+:LeaderfCommand                                 *LeaderfCommand*
+    Launch LeaderF to execute user-defined/built-in Ex commands.
+
 :LeaderfRgInteractive                           *LeaderfRgInteractive*
     Launch LeaderF to use rg interactively.
 
@@ -914,7 +917,7 @@ Once LeaderF is launched:                       *prompt* *leaderf-prompt*
     <C-Up> : scroll up in the popup preview window.
     <C-Down> : scroll down in the popup preview window.
 
-    cmdHistory/searchHistory only mappings:
+    cmdHistory/searchHistory/command only mappings:
         <C-o> : edit command under cursor.
 
 ==============================================================================


### PR DESCRIPTION
I tried to implement `command` which is one of #451.

When executing a command, if a command requires an argument (`E471`), it can now be automatically entered on the command line.

Also, the line can be edited with `e` (normal mode) or `C-o` (input mode) like cmdHistory/searchHistory.

Please let us know if any changes are missing.

Thank you.