### PR TITLE
Fix editHistory()

### DIFF
--- a/autoload/leaderf/python/leaderf/historyExpl.py
+++ b/autoload/leaderf/python/leaderf/historyExpl.py
@@ -125,7 +125,7 @@ class HistoryExplManager(Manager):
         line = instance.currentLine
         edit_prompt = lfEval("g:Lf_HistoryEditPromptIfEmpty") == "1"
         if edit_prompt and len(line.strip()) == 0:
-            line = instance._cli.pattern
+            line = ''.join(instance._cli._cmdline)
 
         instance.exitBuffer()
         cmd = ":"


### PR DESCRIPTION
Use `instance._cli._cmdline` instead of `instance._cli.pattern`.


```
function leaderf#Any#start[4]..leaderf#LfPy の処理中にエラーが検出されました:
行    1:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\anyExpl.py", line 788, in start
    the_args.start(arguments, *args, **kwargs)
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\anyExpl.py", line 720, in _default_action
    manager.startExplorer(win_pos[2:], *args, **kwargs)
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\manager.py", line 2015, in startExplorer
    self.input()
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\manager.py", line 57, in deco
    func(self, *args, **kwargs)
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\manager.py", line 2410, in input
    if self._cmdExtension(cmd):
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\historyExpl.py", line 119, in _cmdExtension
    self.editHistory()
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\historyExpl.py", line 136, in editHistory
    lfCmd("call feedkeys('%s')" % (cmd + escQuote(line)))
  File "C:\Users\tamago324\vimfiles\plugged\LeaderF\autoload\leaderf\python\leaderf\utils.py", line 123, in escQuote
    return "" if str is None else str.replace("'","''")
AttributeError: 'tuple' object has no attribute 'replace'
```