### PR TITLE
Output quickfix

### DIFF
--- a/autoload/leaderf/Rg.vim
+++ b/autoload/leaderf/Rg.vim
@@ -35,6 +35,8 @@ function! leaderf#Rg#Maps()
     nnoremap <buffer> <silent> <Tab>         :exec g:Lf_py "rgExplManager.input()"<CR>
     nnoremap <buffer> <silent> <F1>          :exec g:Lf_py "rgExplManager.toggleHelp()"<CR>
     nnoremap <buffer> <silent> d             :exec g:Lf_py "rgExplManager.deleteCurrentLine()"<CR>
+    nnoremap <buffer> <silent> Q             :exec g:Lf_py "rgExplManager.outputToQflist()"<CR>
+    nnoremap <buffer> <silent> L             :exec g:Lf_py "rgExplManager.outputToLoclist()"<CR>
     if has("nvim")
         nnoremap <buffer> <silent> <C-Up>    :exec g:Lf_py "rgExplManager._toUpInPopup()"<CR>
         nnoremap <buffer> <silent> <C-Down>  :exec g:Lf_py "rgExplManager._toDownInPopup()"<CR>
@@ -187,6 +189,10 @@ function! leaderf#Rg#NormalModeFilter(winid, key) abort
         exec g:Lf_py "rgExplManager.toggleHelp()"
     elseif key ==# "d"
         exec g:Lf_py "rgExplManager.deleteCurrentLine()"
+    elseif key ==# "Q"
+        exec g:Lf_py "rgExplManager.outputToQflist()"
+    elseif key ==# "L"
+        exec g:Lf_py "rgExplManager.outputToLoclist()"
     elseif key ==? "<C-Up>"
         exec g:Lf_py "rgExplManager._toUpInPopup()"
     elseif key ==? "<C-Down>"

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -618,11 +618,7 @@ class RgExplManager(Manager):
         # ^^^^---->
         patterns.extend([x[4:] for x in self._getExplorer().getPatternRegex()[1:]])
         regexp = '|'.join(patterns)
-        if reg == "/":
-            # no highlight
-            lfCmd("let @/ = '%s'" % regexp)
-        else:
-            lfCmd("call setreg('%s', '%s')" % (reg, regexp))
+        lfCmd("let @%s = '%s'" % (reg, regexp))
 
     def _bangEnter(self):
         super(RgExplManager, self)._bangEnter()

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -610,6 +610,15 @@ class RgExplManager(Manager):
                 k.options["cursorline"] = v
         self._cursorline_dict.clear()
 
+        reg = lfEval("get(g:, 'Lf_RgStorePattern', '')")
+        if reg == '':
+            return
+        patterns = self._getExplorer().getPatternRegex()[:1]
+        # \v\cRegex
+        # ^^^^---->
+        patterns.extend([x[4:] for x in self._getExplorer().getPatternRegex()[1:]])
+        lfCmd("call setreg('%s', '%s')" % (reg, '|'.join(patterns)))
+
     def _bangEnter(self):
         super(RgExplManager, self)._bangEnter()
         if lfEval("exists('*timer_start')") == '0':

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -6,6 +6,7 @@ import re
 import os
 import os.path
 import tempfile
+import json
 from functools import wraps
 from .utils import *
 from .explorer import *
@@ -535,6 +536,8 @@ class RgExplManager(Manager):
         help.append('" t : open file under cursor in a new tabpage')
         help.append('" p : preview the result')
         help.append('" d : delete the line under the cursor')
+        help.append('" Q : output result quickfix list ')
+        help.append('" L : output result location list ')
         help.append('" i/<Tab> : switch to input mode')
         help.append('" q : quit')
         help.append('" <F1> : toggle this help')
@@ -768,6 +771,30 @@ class RgExplManager(Manager):
 
         self._createPopupPreview("", buf_number, line_num)
 
+    def outputToQflist(self, *args, **kwargs):
+        items = self._getFormatedContents()
+        lfCmd("call setqflist(%s, 'r')" % json.dumps(items))
+        lfCmd("echohl WarningMsg | redraw | echo ' Output result to quickfix list.' | echohl NONE")
+
+    def outputToLoclist(self, *args, **kwargs):
+        items = self._getFormatedContents()
+        winnr = lfEval('bufwinnr(%s)' % self._cur_buffer.number)
+        lfCmd("call setloclist(%d, %s, 'r')" % (int(winnr), json.dumps(items)))
+        lfCmd("echohl WarningMsg | redraw | echo ' Output result to location list.' | echohl NONE")
+
+    def _getFormatedContents(self):
+        items = []
+        for line in self._instance._buffer_object:
+            m = re.match(r'^(?:\.[\\/])?([^:]+):(\d+):(.*)$', line)
+            if m:
+                fpath, lnum, text = m.group(1, 2, 3)
+                items.append({
+                    "filename": fpath,
+                    "lnum": lnum,
+                    "col": 1,
+                    "text": text,
+                })
+        return items
 
 #*****************************************************
 # rgExplManager is a singleton

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -617,7 +617,12 @@ class RgExplManager(Manager):
         # \v\cRegex
         # ^^^^---->
         patterns.extend([x[4:] for x in self._getExplorer().getPatternRegex()[1:]])
-        lfCmd("call setreg('%s', '%s')" % (reg, '|'.join(patterns)))
+        regexp = '|'.join(patterns)
+        if reg == "/":
+            # no highlight
+            lfCmd("let @/ = '%s'" % regexp)
+        else:
+            lfCmd("call setreg('%s', '%s')" % (reg, regexp))
 
     def _bangEnter(self):
         super(RgExplManager, self)._bangEnter()

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -570,6 +570,21 @@ g:Lf_RgConfig                                   *g:Lf_RgConfig*
 <
     Default value is [].
 
+g:Lf_RgStorePattern                             *g:Lf_RgStorePattern*
+    Specify the register to store the search pattern when you exit LeaderF.
+    The pattern entered with `-e` of the `Leaderf rg` command is stored. Also,
+    patterns are converted to Vim's regexp.
+
+    For example, When there is one pattern:
+        When executed in `Leaderf rg -e "pat1"`, `/\v\cpat1` is stored.
+
+    For example, When there are multiple patterns:
+        If multiple patterns are specified, they will be joined with `|`.
+        When executed in `Leaderf rg -e "pat1" -e "pat2"`, `/\v\cpat1|pat2` is
+        stored.
+
+    Default value is "".
+
 g:Lf_MaxCount                                   *g:Lf_MaxCount*
     Specify the limit of the number of source entries. LeaderF will stop
     producing the source entries if the limit is hit. There is no limit if the


### PR DESCRIPTION
You can output the result of filtering.
`Q` (quickfix list) and `L` (location list) can be output in `normal` mode.

Also added the `g:Lf_RgStorePattern` option to save the search pattern specified by `-e` in the register.

Refer #447.