### PR TITLE
Add Gtags commonly used mapping as <Plug>

### DIFF
--- a/autoload/leaderf/Gtags.vim
+++ b/autoload/leaderf/Gtags.vim
@@ -48,6 +48,40 @@ function! leaderf#Gtags#Maps()
     endif
 endfunction
 
+" return the visually selected text and quote it with double quote
+function! leaderf#Gtags#visual()
+    try
+        let x_save = @x
+        norm! gv"xy
+        return '"' . escape(@x, '"') . '"'
+    finally
+        let @x = x_save
+    endtry
+endfunction
+
+" type: 0, word under cursor
+"       1, WORD under cursor
+"       2, text visually selected
+function! leaderf#Gtags#getPattern(type)
+    if a:type == 0
+        return expand('<cword>')
+    elseif a:type == 1
+        return escape(expand('<cWORD>'))
+    elseif a:type == 2
+        return leaderf#Gtags#visual()
+    else
+        return ''
+    endif
+endfunction
+
+" type: 0, word under cursor
+"       1, WORD under cursor
+"       2, text visually selected
+function! leaderf#Gtags#startCmdline(type, is_bang, param)
+    return printf("Leaderf%s gtags -%s %s --literal --auto-jump", a:is_bang ? '!' : '',
+                \ a:param, leaderf#Gtags#getPattern(a:type))
+endfunction
+
 function! leaderf#Gtags#cleanup()
 exec g:Lf_py "<< EOF"
 gtagsExplManager._beforeExit()

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -910,6 +910,15 @@ Some handy maps for `Leaderf rg`:
 | `<Plug>LeaderfRgVisualRegexBoundary`         | search visually selected text treated as regex with `-w` option
 | `<Plug>LeaderfRgBangVisualRegexBoundary`     | like `<Plug>LeaderfRgVisualRegexBoundary`, but with a bang(`!`)
 
+Some handy maps for `Leaderf gtags`:
+
+| Map                                        | Description
+| ---                                        | -----------
+| `<Plug>LeaderfGtagsDefinition`               | Show <cword> or selected text locations of definitions.
+| `<Plug>LeaderfGtagsReference`                | Show <cword> or selected text reference to a symbol which has definitions.
+| `<Plug>LeaderfGtagsSymbol`                   | Show <cword> or selected text reference to a symbol which has no definition.
+| `<Plug>LeaderfGtagsGrep`                     | Show all lines which match to the <cword> or selected text .
+
 Once LeaderF is launched:                       *prompt* *leaderf-prompt*
     <C-C>, <ESC> : quit from LeaderF.
     <C-R> : switch between fuzzy search mode and regex mode.

--- a/plugin/leaderf.vim
+++ b/plugin/leaderf.vim
@@ -115,6 +115,16 @@ vnoremap <silent> <Plug>LeaderfRgBangVisualLiteralBoundary   :<C-U><C-R>=leaderf
 vnoremap <silent> <Plug>LeaderfRgBangVisualRegexNoBoundary   :<C-U><C-R>=leaderf#Rg#startCmdline(2, 1, 1, 0)<CR>
 vnoremap <silent> <Plug>LeaderfRgBangVisualRegexBoundary     :<C-U><C-R>=leaderf#Rg#startCmdline(2, 1, 1, 1)<CR>
 
+noremap <Plug>LeaderfGtagsDefinition :<C-U><C-R>=leaderf#Gtags#startCmdline(0, 1, 'd')<CR><CR>
+noremap <Plug>LeaderfGtagsReference :<C-U><C-R>=leaderf#Gtags#startCmdline(0, 1, 'r')<CR><CR>
+noremap <Plug>LeaderfGtagsSymbol :<C-U><C-R>=leaderf#Gtags#startCmdline(0, 1, 's')<CR><CR>
+noremap <Plug>LeaderfGtagsGrep :<C-U><C-R>=leaderf#Gtags#startCmdline(0, 1, 'g')<CR><CR>
+
+vnoremap <silent> <Plug>LeaderfGtagsDefinition :<C-U><C-R>=leaderf#Gtags#startCmdline(2, 1, 'd')<CR><CR>
+vnoremap <silent> <Plug>LeaderfGtagsReference :<C-U><C-R>=leaderf#Gtags#startCmdline(2, 1, 'r')<CR><CR>
+vnoremap <silent> <Plug>LeaderfGtagsSymbol :<C-U><C-R>=leaderf#Gtags#startCmdline(2, 1, 's')<CR><CR>
+vnoremap <silent> <Plug>LeaderfGtagsGrep :<C-U><C-R>=leaderf#Gtags#startCmdline(2, 1, 'g')<CR><CR>
+
 command! -bar -nargs=? -complete=dir LeaderfFile Leaderf file <args>
 command! -bar -nargs=? -complete=dir LeaderfFileFullScreen Leaderf file --fullScreen <args>
 command! -bar -nargs=1 LeaderfFilePattern Leaderf file --input <args>


### PR DESCRIPTION
Add:
| Map                                        | Description
| ---                                        | -----------
| `<Plug>LeaderfGtagsDefinition`               | Show <cword> or selected text locations of definitions.
| `<Plug>LeaderfGtagsReference`                | Show <cword> or selected text reference to a symbol which has definitions.
| `<Plug>LeaderfGtagsSymbol`                   | Show <cword> or selected text reference to a symbol which has no definition.
| `<Plug>LeaderfGtagsGrep`                     | Show all lines which match to the <cword> or selected text .