### PR TITLE
fix building fuzzy match extension with old gcc

### DIFF
--- a/autoload/leaderf/fuzzyMatch_C/setup.py
+++ b/autoload/leaderf/fuzzyMatch_C/setup.py
@@ -24,10 +24,14 @@ if os.name == 'nt':
 
 
 module1 = Extension("fuzzyMatchC",
-                    sources = ["fuzzyMatch.c"])
+                    sources = ["fuzzyMatch.c"],
+                    extra_compile_args = ["-std=c99"]
+                    )
 
 module2 = Extension("fuzzyEngine",
-                    sources = ["fuzzyMatch.c", "fuzzyEngine.c"])
+                    sources = ["fuzzyMatch.c", "fuzzyEngine.c"],
+                    extra_compile_args = ["-std=c99"]
+                    )
 
 
 setup(name = "fuzzyEngine",


### PR DESCRIPTION
gcc 4.8.5 failed to build the fuzzy match extension, messages list below

```bash
fuzzyEngine.c: In function ‘rg_getDigest’:
fuzzyEngine.c:1432:13: error: ‘for’ loop initial declarations are only allowed in C99 mode
             for ( char *p = s; p < s + len; ++p )
             ^
fuzzyEngine.c:1432:13: note: use option -std=c99 or -std=gnu99 to compile your code
fuzzyEngine.c:1460:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for ( char *p = s; p < s + len; ++p )
         ^
```