### PR TITLE
autocmd ColorScheme call highlightDevIcons()

### DIFF
--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -855,3 +855,9 @@ function! leaderf#setAmbiwidth(val) abort
     exec g:Lf_py "from leaderf.devicons import setAmbiwidth"
     exec g:Lf_py printf("setAmbiwidth('%s')", a:val)
 endfunction
+
+autocmd ColorScheme * call leaderf#highlightDevIcons()
+function! leaderf#highlightDevIcons() abort
+    exec g:Lf_py 'from leaderf.devicons import highlightDevIcons'
+    exec g:Lf_py 'highlightDevIcons()'
+endfunction

--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -856,7 +856,6 @@ function! leaderf#setAmbiwidth(val) abort
     exec g:Lf_py printf("setAmbiwidth('%s')", a:val)
 endfunction
 
-autocmd ColorScheme * call leaderf#highlightDevIcons()
 function! leaderf#highlightDevIcons() abort
     exec g:Lf_py 'from leaderf.devicons import highlightDevIcons'
     exec g:Lf_py 'highlightDevIcons()'

--- a/autoload/leaderf/python/leaderf/devicons.py
+++ b/autoload/leaderf/python/leaderf/devicons.py
@@ -251,6 +251,9 @@ def matchaddDevIconsExtension(pattern, winid=None):
     return _matchadd(fileNodesExtensionSymbols, pattern, 7, winid)
 
 def highlightDevIcons():
+    if not vim.vars.get('Lf_ShowDevIcons', True):
+        return
+
     icon_font = lfEval("get(g:, 'Lf_DevIconsFont', '')")
 
     devicons_palette = lfEval("get(g:, 'Lf_DevIconsPallete', {})")

--- a/autoload/leaderf/python/leaderf/instance.py
+++ b/autoload/leaderf/python/leaderf/instance.py
@@ -730,6 +730,7 @@ class LfInstance(object):
                   .format(self._category))
             lfCmd("autocmd ColorScheme * call leaderf#colorscheme#highlightMode('{0}', g:Lf_{0}_StlMode)"
                   .format(self._category))
+            lfCmd("autocmd ColorScheme * call leaderf#highlightDevIcons()")
             lfCmd("autocmd ColorScheme <buffer> doautocmd syntax")
             lfCmd("autocmd CursorMoved <buffer> let g:Lf_{}_StlLineNumber = 1 + line('$') - line('.')"
                   .format(self._category))


### PR DESCRIPTION
When the colorscheme was loaded, `hi clear` was executed, removing the icon's highlights.

Is this the right way to go?