### PR TITLE
Fix bufname min length

### DIFF
--- a/autoload/leaderf/python/leaderf/bufExpl.py
+++ b/autoload/leaderf/python/leaderf/bufExpl.py
@@ -61,7 +61,7 @@ class BufferExplorer(Explorer):
 
         self._max_bufname_len = max([int(lfEval("strdisplaywidth('%s')"
                                         % escQuote(getBasename(buffers[nr].name))))
-                                    for nr in mru.getMruBufnrs() if nr in buffers] or [0])
+                                    for nr in mru.getMruBufnrs() if nr in buffers] + [len('[No Name]')] or [0])
 
         bufnames = []
         for nr in mru.getMruBufnrs():


### PR DESCRIPTION
Added `len('[No Name]')` to the minimum buffer name length.