### PR TITLE
Fix can't delete if less than help length

### DIFF
--- a/autoload/leaderf/python/leaderf/bufExpl.py
+++ b/autoload/leaderf/python/leaderf/bufExpl.py
@@ -247,7 +247,7 @@ class BufExplManager(Manager):
 
     def deleteBuffer(self, wipe=0):
         instance = self._getInstance()
-        if instance.window.cursor[0] <= self._help_length:
+        if self._inHelpLines():
             return
         if instance.getWinPos() == 'popup':
             lfCmd("call win_execute(%d, 'setlocal modifiable')" % instance.getPopupWinId())

--- a/autoload/leaderf/python/leaderf/gtagsExpl.py
+++ b/autoload/leaderf/python/leaderf/gtagsExpl.py
@@ -1108,7 +1108,7 @@ class GtagsExplManager(Manager):
 
     def deleteCurrentLine(self):
         instance = self._getInstance()
-        if instance.window.cursor[0] <= self._help_length:
+        if self._inHelpLines():
             return
         if instance.getWinPos() == 'popup':
             lfCmd("call win_execute(%d, 'setlocal modifiable')" % instance.getPopupWinId())

--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -775,6 +775,14 @@ class Manager(object):
         self._help_length = 0
         self._getInstance().refreshPopupStatusline()
 
+    def _inHelpLines(self):
+        if self._getInstance().isReverseOrder():
+            if self._getInstance().window.cursor[0] > len(self._getInstance().buffer) - self._help_length:
+                return True
+        elif self._getInstance().window.cursor[0] <= self._help_length:
+            return True
+        return False
+
     def _getExplorer(self):
         if self._explorer is None:
             self._explorer = self._getExplClass()()

--- a/autoload/leaderf/python/leaderf/mruExpl.py
+++ b/autoload/leaderf/python/leaderf/mruExpl.py
@@ -264,7 +264,7 @@ class MruExplManager(Manager):
 
     def deleteMru(self):
         instance = self._getInstance()
-        if instance.window.cursor[0] <= self._help_length:
+        if self._inHelpLines():
             return
         if instance.getWinPos() == 'popup':
             lfCmd("call win_execute(%d, 'setlocal modifiable')" % instance.getPopupWinId())

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -719,7 +719,7 @@ class RgExplManager(Manager):
 
     def deleteCurrentLine(self):
         instance = self._getInstance()
-        if instance.window.cursor[0] <= self._help_length:
+        if self._inHelpLines():
             return
         if instance.getWinPos() == 'popup':
             lfCmd("call win_execute(%d, 'setlocal modifiable')" % instance.getPopupWinId())


### PR DESCRIPTION
Fixed an issue where a line less than the help length could not be deleted when the display was reversed.