### PR TITLE
Fix format_list error

### DIFF
--- a/autoload/leaderf/python/leaderf/anyExpl.py
+++ b/autoload/leaderf/python/leaderf/anyExpl.py
@@ -137,12 +137,12 @@ class AnyExplorer(Explorer):
             except vim.error as err:
                 raise Exception("Error occurred in user defined %s: %s" % (str(format_list), err))
 
+        if lfEval("has('nvim')") != '1' and isinstance(result, vim.List):
+            result = list(result)
+
         if sys.version_info >= (3, 0):
             if isinstance(result, list) and result and isinstance(result[0], bytes):
                 result = [lfBytes2Str(i) for i in result]
-
-        if lfEval("has('nvim')") != '1' and isinstance(result, vim.List):
-            result = list(result)
 
         return result
 


### PR DESCRIPTION
When I formatted the list with format_list, I got the following error:
```
Messages maintainer: Bram Moolenaar <Bram@vim.org>
Error detected while processing function leaderf#Any#start[4]..leaderf#LfPy:
line    1:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\user\ghq\github.com\tamago324\LeaderF\autoload\leaderf\python\leaderf\anyExpl.py", line 797, in start
    the_args.start(arguments, *args, **kwargs)
  File "C:\Users\user\ghq\github.com\tamago324\LeaderF\autoload\leaderf\python\leaderf\anyExpl.py", line 729, in _default_action
    manager.startExplorer(win_pos[2:], *args, **kwargs)
  File "C:\Users\user\ghq\github.com\tamago324\LeaderF\autoload\leaderf\python\leaderf\anyExpl.py", line 367, in startExplorer
    super(AnyExplManager, self).startExplorer(win_pos, *args, **kwargs)
  File "C:\Users\user\ghq\github.com\tamago324\LeaderF\autoload\leaderf\python\leaderf\manager.py", line 2036, in startExplorer
    if len(content[0]) == len(content[0].rstrip("\r\n")):
TypeError: a bytes-like object is required, not 'str'
```


The result of `format_list()` was of type `vim.list`, not `list`.
Therefore, the conversion from `vim.list` to `list` will be done first.

Thank you!