### PR TITLE
Common normal map

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -126,6 +126,17 @@ class Manager(object):
     def _defineMaps(self):
         pass
 
+    def _defineCommonMaps(self):
+        normal_map = lfEval("get(g:, 'Lf_NormalMap', {})")
+        if "_" not in normal_map: 
+            return
+
+        for [lhs, rhs] in normal_map["_"]:
+            # If a buffer-local mapping does not exist, map it
+            maparg = lfEval("maparg('{}', 'n', 0, 1)".format(lhs))
+            if maparg == {} or maparg.get("buffer", "0") == "0" :
+                lfCmd("nnoremap <buffer> <silent> {} {}".format(lhs, rhs))
+
     def _cmdExtension(self, cmd):
         """
         this function can be overridden to add new cmd
@@ -248,6 +259,7 @@ class Manager(object):
 
         if self._getInstance().getWinPos() != 'popup':
             self._defineMaps()
+            self._defineCommonMaps()
 
             id = int(lfEval("matchadd('Lf_hl_cursorline', '.*\%#.*', 9)"))
             self._match_ids.append(id)

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -439,8 +439,13 @@ g:Lf_UseCache                                   *g:Lf_UseCache*
 
 g:Lf_NormalMap                                  *g:Lf_NormalMap*
     Use this option to customize the mappings in normal mode.
+    The mapping with the key `"_"` applies to all categories.
+    Also, `"_"` is overridden by the mapping of each category.
     e.g., >
     let g:Lf_NormalMap = {
+        \ "_":      [["<C-j>", "j"],
+        \            ["<C-k>", "k"]
+        \           ],
         \ "File":   [["<ESC>", ':exec g:Lf_py "fileExplManager.quit()"<CR>'],
         \            ["<F6>", ':exec g:Lf_py "fileExplManager.quit()"<CR>']
         \           ],


### PR DESCRIPTION
Added `"_"` to `g:Lf_NormalMap`.

Refer #503.

`"_"` is a mapping that applies to all categories.
Also, the mapping of each category overrides the mapping of `"_"`.

For example, to change the mapping for the File category only, do the following.

```vim
let g:Lf_NormalMap = {
\   "_": [
\      ['<C-j>', 'j'],
\      ['<C-k>', 'k'],
\   ],
\   "File": [
\      ['<C-j>', '<Nop>'],
\      ['<C-k>', '<Nop>'],
\   ],
\}
```

Thank you!