### PR TITLE
Fix preview command [Vim]

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -376,7 +376,8 @@ class Manager(object):
             lfCmd("autocmd! BufwinEnter <buffer> setlocal cursorline<")
             lfCmd("augroup END")
         finally:
-            vim.current.tabpage, vim.current.window, vim.current.buffer = cur_pos
+            if self._getInstance().getWinPos() != 'popup':
+                vim.current.tabpage, vim.current.window, vim.current.buffer = cur_pos
             vim.options['eventignore'] = saved_eventignore
 
     def _restoreOrigCwd(self):


### PR DESCRIPTION
The preview was not working correctly in Vim when viewed with popup.

```
:Leaderf file --popup
```

The settings are as follows.

```
let g:Lf_PreviewInPopup = 0
```

Refer https://github.com/tamago324/LeaderF-filer/issues/31.

Thank you.