### PR TITLE
Fix preview poup title

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -4,6 +4,7 @@
 import vim
 import os
 import sys
+import json
 import time
 import operator
 import itertools
@@ -558,7 +559,7 @@ class Manager(object):
                 options["maxheight"] = maxheight
                 options["minheight"] = maxheight
 
-            lfCmd("silent! let winid = popup_create(%d, %s)" % (buf_number, str(options)))
+            lfCmd("silent! let winid = popup_create(%d, %s)" % (buf_number, json.dumps(options)))
             self._preview_winid = int(lfEval("winid"))
             if jump_cmd:
                 lfCmd("""call win_execute(%d, '%s')""" % (self._preview_winid, escQuote(jump_cmd)))
@@ -680,7 +681,7 @@ class Manager(object):
                 options["maxheight"] = maxheight
                 options["minheight"] = maxheight
 
-            lfCmd("silent! let winid = popup_create(%d, %s)" % (buf_number, str(options)))
+            lfCmd("silent! let winid = popup_create(%d, %s)" % (buf_number, json.dumps(options)))
             self._preview_winid = int(lfEval("winid"))
             if jump_cmd:
                 lfCmd("""call win_execute(%d, '%s')""" % (self._preview_winid, escQuote(jump_cmd)))


### PR DESCRIPTION
The title of the popup preview will now show an icon.

Refer https://github.com/tamago324/LeaderF-filer/issues/31#issuecomment-616007459

Before:

![image](https://user-images.githubusercontent.com/16581287/79678321-0bbc7880-8235-11ea-83c9-bb90783937df.png)

After:

![image](https://user-images.githubusercontent.com/16581287/79678325-137c1d00-8235-11ea-951d-8a172d031585.png)

Thank you!