### PR TITLE
Fix garbled in VimScript extensions [Win10]

### DIFF
--- a/autoload/leaderf/python/leaderf/anyExpl.py
+++ b/autoload/leaderf/python/leaderf/anyExpl.py
@@ -142,7 +142,7 @@ class AnyExplorer(Explorer):
 
         if sys.version_info >= (3, 0):
             if isinstance(result, list) and result and isinstance(result[0], bytes):
-                result = [lfBytes2Str(i, 'utf-8') for i in result]
+                result = [lfBytes2Str(i, lfEval("&encoding")) for i in result]
 
         return result
 

--- a/autoload/leaderf/python/leaderf/anyExpl.py
+++ b/autoload/leaderf/python/leaderf/anyExpl.py
@@ -142,7 +142,7 @@ class AnyExplorer(Explorer):
 
         if sys.version_info >= (3, 0):
             if isinstance(result, list) and result and isinstance(result[0], bytes):
-                result = [lfBytes2Str(i) for i in result]
+                result = [lfBytes2Str(i, 'utf-8') for i in result]
 
         return result
 


### PR DESCRIPTION
Some Japanese Kanji characters were garbled, so that has been fixed.
I'm sorry, but I haven't been able to confirm that it doesn't affect other languages.

<details>
<summary>minvimrc</summary>

```vim
set encoding=utf-8
scriptencoding utf-8

syntax enable
filetype plugin indent on

set nocompatible

set runtimepath^=~/ghq/github.com/tamago324/LeaderF

" no backup
set nobackup
set nowritebackup

" no swap
set noswapfile
set updatecount=0

" 消せる文字
set backspace=indent,eol,start

nnoremap <silent> <Space>q :<C-u>quit<CR>
nnoremap <silent> <Space>Q :<C-u>quit!<CR>


" ====================
" help
" ====================
let s:fav_helps = [
\   ['function-list',      '関数一覧'],
\   ['user-commands',      'command の書き方'],
\   ['autocmd-events',     'autocmd 一覧'],
\   ['E500',               '<cword> とか <afile> とか'],
\   ['usr_41',             'Vim script 基本'],
\   ['pattern-overview',   '正規表現'],
\   ['eval',               'Vim script [tips]'],
\   ['ex-cmd-index',       '":"のコマンド'],
\   ['filename-modifiers', ':p とか :h とか'],
\   ['index',              '各モードのマッピング'],
\   ['popup-window',       'ポップアップのヘルプ'],
\   ['job-options',        'job のオプション集'],
\]

function! LfFavhelpSource(args) abort
    return s:space_between(s:fav_helps)
endfunction

function! LfFavhelpAccept(line, args) abort
    exec 'help ' . trim(split(a:line, '|')[0])
endfunction

function! s:space_between(line_items) abort
    let l:result = []
    let l:max_len = max(map(copy(a:line_items), {_,x -> strdisplaywidth(x[0])}) + [0])
    for l:line_item in a:line_items
        let l:space = l:max_len - strdisplaywidth(l:line_item[0])
        call add(l:result, printf('%s%s | %s', l:line_item[0], repeat(' ', l:space), l:line_item[1]))
    endfor
    return l:result
endfunction

let g:Lf_Extensions = {}
let g:Lf_Extensions.favhelp = {
\   'source': 'LfFavhelpSource',
\   'accept': 'LfFavhelpAccept',
\}

colorscheme morning
```

</details>


Before:
<img src="https://user-images.githubusercontent.com/16581287/80546387-749faf80-89f0-11ea-9eb8-6d5514d8c8d5.png" width=500>

After:
<img src="https://user-images.githubusercontent.com/16581287/80546446-9d27a980-89f0-11ea-9ea4-be0ff82d647c.png" width=500>