### PR TITLE
Fix one and gruvbox_material palette names

### DIFF
--- a/autoload/leaderf/colorscheme/gruvbox_material.vim
+++ b/autoload/leaderf/colorscheme/gruvbox_material.vim
@@ -214,4 +214,4 @@ else
                 \ }
 endif
 
-let g:leaderf#colorscheme#default#palette = leaderf#colorscheme#mergePalette(s:palette)
+let g:leaderf#colorscheme#gruvbox_material#palette = leaderf#colorscheme#mergePalette(s:palette)

--- a/autoload/leaderf/colorscheme/one.vim
+++ b/autoload/leaderf/colorscheme/one.vim
@@ -110,4 +110,4 @@ let s:palette = {
             \   }
             \ }
 
-let g:leaderf#colorscheme#default#palette = leaderf#colorscheme#mergePalette(s:palette)
+let g:leaderf#colorscheme#one#palette = leaderf#colorscheme#mergePalette(s:palette)


### PR DESCRIPTION
Using `default` was preventing these colorschemes from being used.