### PR TITLE
fix leaderf blink if input contains `\n`

### DIFF
--- a/autoload/leaderf/python/leaderf/cli.py
+++ b/autoload/leaderf/python/leaderf/cli.py
@@ -104,6 +104,8 @@ class LfCli(object):
 
     def _paste(self):
         for ch in lfEval("@*"):
+            if ch == '\n':
+                break
             self._insert(ch)
 
     def _backspace(self):
@@ -795,4 +797,3 @@ class LfCli(object):
         except vim.error: # for neovim
             lfCmd("call getchar(0)")
             yield '<Quit>'
-


### PR DESCRIPTION
This PR solves the problem shown in the gif below.

![Peek 2020-05-10 12-15](https://user-images.githubusercontent.com/20282795/81490725-23c56c00-92b8-11ea-98c3-a1744e246a0d.gif)

In the gif above, I use `V` to select the line. Then type `<C-v>` to paste the content. The char `\n` at the end of the line leads to blink problem.

Also I propose that we should avoid multiple lines as input. Therefore I made a line break at the first `\n`.