### PR TITLE
update vim vars before gtags update

### DIFF
--- a/autoload/leaderf/python/leaderf/gtagsExpl.py
+++ b/autoload/leaderf/python/leaderf/gtagsExpl.py
@@ -94,6 +94,7 @@ class GtagsExplorer(Explorer):
             self._gtagslibpath = []
 
         if "--update" in arguments_dict:
+            self._evalVimVar()
             if "--accept-dotfiles" in arguments_dict:
                 self._accept_dotfiles = "--accept-dotfiles "
             if "--skip-unreadable" in arguments_dict:


### PR DESCRIPTION
update vim vars before gtags update.
then I can modify some vim var like `g:Lf_WildIgnore`, and update gtags without reopen vim.