### PR TITLE
only use `drop` to open selected if the buffer already exists

### DIFF
--- a/autoload/leaderf/python/leaderf/gtagsExpl.py
+++ b/autoload/leaderf/python/leaderf/gtagsExpl.py
@@ -912,7 +912,7 @@ class GtagsExplManager(Manager):
             if kwargs.get("mode", '') == 't':
                 lfCmd("tab drop %s | %s" % (escSpecial(file), line_num))
             else:
-                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1':
+                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1' and lfEval("bufexists('%s')" % escQuote(file)) == '1':
                     lfCmd("keepj hide drop %s | %s" % (escSpecial(file), line_num))
                 else:
                     lfCmd("hide edit +%s %s" % (line_num, escSpecial(file)))

--- a/autoload/leaderf/python/leaderf/mruExpl.py
+++ b/autoload/leaderf/python/leaderf/mruExpl.py
@@ -148,7 +148,7 @@ class MruExplManager(Manager):
             if kwargs.get("mode", '') == 't':
                 lfCmd("tab drop %s" % escSpecial(file))
             else:
-                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1':
+                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1' and lfEval("bufexists('%s')" % escQuote(file)) == '1':
                     lfCmd("keepj hide drop %s" % escSpecial(file))
                 else:
                     lfCmd("hide edit %s" % escSpecial(file))

--- a/autoload/leaderf/python/leaderf/qfloclistExpl.py
+++ b/autoload/leaderf/python/leaderf/qfloclistExpl.py
@@ -72,7 +72,7 @@ class QfLocListExplManager(Manager):
             if kwargs.get("mode", '') == 't':
                 lfCmd("tab drop %s" % escSpecial(file))
             else:
-                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1':
+                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1' and lfEval("bufexists('%s')" % escQuote(file)) == '1':
                     lfCmd("keepj hide drop %s" % escSpecial(file))
                 else:
                     lfCmd("hide edit %s" % escSpecial(file))

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -400,7 +400,7 @@ class RgExplManager(Manager):
     def _acceptSelection(self, *args, **kwargs):
         if len(args) == 0:
             return
-        
+
         if args[0] == self._getExplorer().getContextSeparator():
             return
 
@@ -447,7 +447,7 @@ class RgExplManager(Manager):
                 if kwargs.get("mode", '') == 't':
                     lfCmd("tab drop %s | %s" % (escSpecial(file), line_num))
                 else:
-                    if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1':
+                    if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1' and lfEval("bufexists('%s')" % escQuote(file)) == '1':
                         lfCmd("keepj hide drop %s | %s" % (escSpecial(file), line_num))
                     else:
                         lfCmd("hide edit +%s %s" % (line_num, escSpecial(file)))

--- a/autoload/leaderf/python/leaderf/tagExpl.py
+++ b/autoload/leaderf/python/leaderf/tagExpl.py
@@ -80,7 +80,7 @@ class TagExplManager(Manager):
             if kwargs.get("mode", '') == 't':
                 lfCmd("tab drop %s" % escSpecial(tagfile))
             else:
-                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1':
+                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1' and lfEval("bufexists('%s')" % escQuote(tagfile)) == '1':
                     lfCmd("keepj hide drop %s" % escSpecial(tagfile))
                 else:
                     lfCmd("hide edit %s" % escSpecial(tagfile))


### PR DESCRIPTION
This PR solves the following issue:

## Description
- Start nvim/vim and there will be a `[No Name]` buffer stays here
- `:Leaderf rg`
- Press `<CR>` to open an arbitrary file

Then the file will be opened in a new buffer, while that `[No Name]` buffer still exists.
Normally the `[No Name]` buffer should be replaced by that file.

This also occurs when I use `mru`, `gtags`, etc. But `:Leaderf file` works normally. So I made some changes corresponding to  `fileExpl.py`.

## Screenshots

- before
![before](https://user-images.githubusercontent.com/20282795/84050151-ef8cba80-a9df-11ea-9ba4-524dd414580c.gif)

- after
![after](https://user-images.githubusercontent.com/20282795/84050161-f1ef1480-a9df-11ea-8a65-9eea7ebb8057.gif)