### PR TITLE
escSpecial escapes dollar mark

### DIFF
--- a/autoload/leaderf/python/leaderf/utils.py
+++ b/autoload/leaderf/python/leaderf/utils.py
@@ -123,7 +123,7 @@ def escQuote(str):
     return "" if str is None else str.replace("'","''")
 
 def escSpecial(str):
-    return re.sub('([%#" ])', r"\\\1", str)
+    return re.sub('([%#$" ])', r"\\\1", str)
 
 def equal(str1, str2, ignorecase=True):
     if ignorecase:


### PR DESCRIPTION
I am using a frontend framework that use `/somepage/$id/index.tsx` to do routing. But LeaderF cannot open file with `$`  in the path name.