### PR TITLE
More compatible with other statusline plugin.

### DIFF
--- a/autoload/leaderf/python/leaderf/instance.py
+++ b/autoload/leaderf/python/leaderf/instance.py
@@ -995,7 +995,8 @@ class LfInstance(object):
             lfCmd("autocmd! ColorScheme * call leaderf#highlightDevIcons()")
             lfCmd("augroup END")
 
-        self._setStatusline()
+        if lfEval("get(g:, 'Lf_DisableStl', 0)")=="0":
+            self._setStatusline()
         self._after_enter()
 
     def exitBuffer(self):

--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -2058,6 +2058,8 @@ class Manager(object):
         self._bang_start_time = self._start_time
         self._bang_count = 0
 
+        self._getInstance().buffer.vars['Lf_category'] = self._getExplorer().getStlCategory()
+ 
         self._read_content_exception = None
         if isinstance(content, list):
             self._is_content_list = True

--- a/doc/leaderf.txt
+++ b/doc/leaderf.txt
@@ -187,6 +187,13 @@ g:Lf_NumberOfHighlight                          *g:Lf_NumberOfHighlight*
     Specify the number of highlight lines in the result.
     Default value is 100.
 
+g:Lf_DisableStl                                 *g:Lf_StlColorscheme*
+    Don't let LeaderF modify statusline.
+    e.g. >
+    let g:Lf_DisableStl = 1
+<
+    g:Lf_DisableStl will not be set by default.
+    
 g:Lf_StlColorscheme                             *g:Lf_StlColorscheme*
     You can configure the colorscheme of statusline for LeaderF.
     e.g. >


### PR DESCRIPTION
* Add a option g:Lf_DisableStl, which will stop LeaderF rendering stasusline
* Add a buffer-scoped variable "b:Lf_category" in LeaderF buffer,
  which stores the category of current LeaderF session, then we
  can use like `eval(printf("g:Lf_%s_StlMode", b:Lf_category))`
  or `eval("get(g:, 'Lf_" . b:Lf_category . "_StlResultsCount', -1)")`
  to get status of LeaderF
* Only test on the plugin lightline
* Some lightline setting example
```vimL
  let g:lightline.active = {
  \ 'left': [ ['mode_', 'paste'], ['filename_', 'filestatus_'] ],
  \ 'right': [ ['percent', 'lineinfo_']
  \}
  let g:lightline.component_function = {
  \   'mode_': 'LightlineMode',
  \   'filename_': 'LightlineFilename',
  \   'filestatus_': 'LightlineFilestatus',
  \   'lineinfo_': 'LightlineLineinfo'
  \}
  function! LightlineMode()
    let fname = expand('%:t')
    return &ft ==# 'nerdtree' ? 'NERDTree' :
    \      &ft ==# 'leaderf' && has_key(b:, 'Lf_category') ? printf('LeaderF %s', b:Lf_category) :
    \      lightline#mode()
  endfunction
  function! LightlineFilename()
    let fname = expand('%:t')
    return fname =~# 'NERD_tree' ? '' :
    \      &ft ==# 'leaderf' && has_key(b:, 'Lf_category') ? eval(printf("g:Lf_%s_StlMode", b:Lf_category)) :
    \      (fname !=# '' ? fname : '[No Name]')
  endfunction
  function! LightlineFilestatus()
    let fname = expand('%:t')
    return fname =~# 'NERD_tree' ? '' :
    \      &ft ==# 'leaderf' && has_key(b:, 'Lf_category') ? eval(printf("g:Lf_%s_StlCwd", b:Lf_category)) :
    \      &readonly ? 'RO' :
    \      &modified ? '+' : '-'
  endfunction
  function! LightlineLineinfo()
    let fname = expand('%:t')
    if &ft ==# 'nerdtree'
        return ''
    elseif &ft ==# 'leaderf' && has_key(b:, 'Lf_category')
        let cnt = eval("get(g:, 'Lf_" . b:Lf_category . "_StlResultsCount', -1)")
        if cnt==-1
            let cnt = eval("get(g:, 'Lf_" . b:Lf_category . "_StlTotal', -1)")
        endif
        return cnt==-1 ? printf('%d/?', line('.')) : printf('%d/%d', line('.'), cnt)
    else
        return printf('%3d:%-2d', line('.'), col('.'))
    endif
  endfunction
```