### PR TITLE
fix leaderf buffer becomes buflisted when invoked again

### DIFF
--- a/autoload/leaderf/python/leaderf/instance.py
+++ b/autoload/leaderf/python/leaderf/instance.py
@@ -733,7 +733,8 @@ class LfInstance(object):
 
         if self._buffer_object is None or not self._buffer_object.valid:
             self._buffer_object = vim.current.buffer
-            self._setAttributes()
+
+        self._setAttributes()
 
         if not self._is_colorscheme_autocmd_set:
             self._is_colorscheme_autocmd_set = True


### PR DESCRIPTION
leaderf buffer, which has been set to `nobuflisted`, became `buflisted` after reopening. We should `_setAttributes` one more time.

![leaderf](https://user-images.githubusercontent.com/20282795/98321870-0f70ea80-2021-11eb-8a26-ed730848f7fe.gif)
