### PR TITLE
Fix :Leaderf file drop option for <C-\> shortcuts not work

### DIFF
--- a/autoload/leaderf/python/leaderf/fileExpl.py
+++ b/autoload/leaderf/python/leaderf/fileExpl.py
@@ -844,7 +844,7 @@ class FileExplManager(Manager):
                 else:
                     lfCmd("tabe %s" % escSpecial(file))
             else:
-                if lfEval("get(g:, 'Lf_JumpToExistingWindow', 1)") == '1' and lfEval("bufloaded('%s')" % escQuote(file)) == '1':
+                if (lfEval("get(g:, 'Lf_JumpToExistingWindow', 1) == '1'") or kwargs.get("mode", 'dr')) and lfEval("bufloaded('%s')" % escQuote(file)) == '1':
                     if (kwargs.get("mode", '') == '' and lfEval("get(g:, 'Lf_DiscardEmptyBuffer', 1)") == '1'
                             and vim.current.buffer.name == ''
                             and vim.current.buffer.number == 1


### PR DESCRIPTION
after set g:Lf_JumpToExistingWindow to 0.

![image](https://user-images.githubusercontent.com/9500049/111659372-2386ed00-8848-11eb-8a92-050f757b601d.png)

如果 `g:Lf_JumpToExistingWindow` 为 0 上图选择Drop就变成Edit了。