### PR TITLE
Fix: gtags preview bug

### DIFF
--- a/autoload/leaderf/python/leaderf/gtagsExpl.py
+++ b/autoload/leaderf/python/leaderf/gtagsExpl.py
@@ -1216,7 +1216,7 @@ class GtagsExplManager(Manager):
             file = os.path.normpath(lfEncode(file))
 
         if lfEval("bufloaded('%s')" % escQuote(file)) == '1':
-            source = int(lfEval("bufadd('%s')" % escQuote(line)))
+            source = int(lfEval("bufadd('%s')" % escQuote(file)))
         else:
             source = file
         self._createPopupPreview("", source, line_num)


### PR DESCRIPTION
Hi! When I try to preview a `Leaderf gtags` result in an exist buffer I get this error

```
Error invoking 'python_execute' on channel 4 (python3-script-host):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 386, in _previewResult
    self._previewInPopup(line, self._getInstance().buffer, line_nr)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/gtagsExpl.py", line 1225, in _previewInPopup
    self._createPopupPreview("", source, line_num)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 91, in deco
    func(self, *args, **kwargs)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 722, in _createPopupPreview
    self._preview_winid = int(lfEval("nvim_open_win(%d, 0, %s)" % (source, str(config))))
  File "/Users/xutianshu/anaconda3/lib/python3.7/site-packages/pynvim/plugin/script_host.py", line 205, in eval
    obj = self.request("vim_eval", expr)
  File "/Users/xutianshu/anaconda3/lib/python3.7/site-packages/pynvim/api/nvim.py", line 182, in request
    res = self._session.request(name, *args, **kwargs)
  File "/Users/xutianshu/anaconda3/lib/python3.7/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
    raise self.error_wrapper(err)
pynvim.api.common.NvimError: Vim:E5555: API call: 'height' key must be a positive Integer
```

I think this is caused by the inconsistency here. The argument of `bufadd()` is not an exist buffer so it will add a new buffer and return its number. 

This easy fix works for me.