### PR TITLE
fix fuzzymatch

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -1179,11 +1179,11 @@ class Manager(object):
 
     def _andModeFilter(self, iterable):
         encoding = lfEval("&encoding")
-        use_fuzzy_engine = False
         cur_content = iterable
         weight_lists = []
         highlight_methods = []
         for p in self._cli.pattern:
+            use_fuzzy_engine = False
             if self._fuzzy_engine and isAscii(p) and self._getUnit() == 1: # currently, only BufTag's _getUnit() is 2
                 use_fuzzy_engine = True
                 pattern = fuzzyEngine.initPattern(p)


### PR DESCRIPTION
This logic error sometimes causes fatal

```
Error invoking 'python_execute' on channel 8 (python2-script-host):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/anyExpl.py", line 815, in start
    the_args.start(arguments, *args, **kwargs)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/anyExpl.py", line 747, in _default_action
    manager.startExplorer(win_pos[2:], *args, **kwargs)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/rgExpl.py", line 884, in startExplorer
    super(RgExplManager, self).startExplorer(win_pos, *args, **kwargs)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 2298, in startExplorer
    self.input()
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 62, in deco
    func(self, *args, **kwargs)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 2524, in input
    self._search(cur_content)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 1071, in _search
    self._fuzzySearch(content, is_continue, step)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 1459, in _fuzzySearch
    pair, highlight_methods = self._filter(step, filter_method, content, is_continue)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 1116, in _filter
    result, highlight_methods = filter_method(cur_content)
  File "/Users/xutianshu/.vim/plugged/LeaderF/autoload/leaderf/python/leaderf/manager.py", line 1241, in _andModeFilter
    result = filter_method(source=tmp_content)
TypeError: _fuzzyFilterEx() got an unexpected keyword argument 'source'
```