### PR TITLE
fix string encoding errors in py2

### DIFF
--- a/autoload/leaderf/python/leaderf/__init__.py
+++ b/autoload/leaderf/python/leaderf/__init__.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 
+if sys.version_info < (3, 0):
+    reload(sys)
+    sys.setdefaultencoding('utf-8')

--- a/autoload/leaderf/python/leaderf/devicons.py
+++ b/autoload/leaderf/python/leaderf/devicons.py
@@ -8,8 +8,8 @@ from functools import wraps
 from .utils import *
 
 # thanks for the icons from https://github.com/ryanoasis/vim-devicons and https://github.com/LinArcX/mpi
-fileNodesDefaultSymbol = ''
-folderNodesDefaultSymbol = ''
+fileNodesDefaultSymbol = u''
+folderNodesDefaultSymbol = u''
 
 fileNodesExactSymbols = {
         'exact-match-case-sensitive-1.txt' : '1',

--- a/autoload/leaderf/python/leaderf/fuzzyMatch.py
+++ b/autoload/leaderf/python/leaderf/fuzzyMatch.py
@@ -25,7 +25,7 @@ else:
     def Unicode(str, encoding):
         try:
             return unicode(str, encoding, 'ignore')
-        except ValueError:
+        except (TypeError, ValueError):
             return str
 
 


### PR DESCRIPTION
Fix issues of string encoding in python2. It sometimes causes Unicode encode/decode errors for non-ascii characters. Discussed in https://github.com/Yggdroot/LeaderF/issues/799.