### PR TITLE
Make input loop less aggressive

### DIFF
--- a/autoload/leaderf/python/leaderf/cli.py
+++ b/autoload/leaderf/python/leaderf/cli.py
@@ -655,7 +655,7 @@ class LfCli(object):
                 if lfEval("has('nvim') && exists('g:GuiLoaded')") == '1':
                     time.sleep(0.005) # this is to solve issue 375 leaderF hangs in nvim-qt
                 else:
-                    time.sleep(0.001)
+                    time.sleep(0.03)
 
                 if lfEval("get(g:, 'Lf_NoAsync', 0)") == '0':
                     lfCmd("let nr = getchar(1)")


### PR DESCRIPTION
Leaderf consumes a lot of CPU time by default just by opening due to the
fact that input is  handled by hot loop instead of event based.
This isn't a real fix, ideally the input function should be only triggered on vim input event.
The patch only solves CPU issue.