### PR TITLE
fix "reverse range in character class" error

### DIFF
--- a/plugin/leaderf.vim
+++ b/plugin/leaderf.vim
@@ -95,7 +95,7 @@ function! s:InstallCExtension(install) abort
 endfunction
 
 augroup LeaderF_Mru
-    autocmd BufAdd,BufEnter,BufWritePost * call lfMru#record(expand(expand('<afile>:p'))) |
+    autocmd BufAdd,BufEnter,BufWritePost * call lfMru#record(expand(expand('<afile>:p:S'))) |
                 \ call lfMru#recordBuffer(expand('<abuf>'))
 augroup END
 


### PR DESCRIPTION
Summary: fix "reverse range in character class" error when triggering autocommand for a buffer with a name containing reverse regex character class (range of chars in square braces like `[a-z]`, but with the right side < left side: `[z-a]`) as a part of a name.
In particular triggers for luadev buffer which has a default name `[nvim-lua]`