### PR TITLE
fixed vim.error: Vim:E118: 函数的参数过多: getcwd in vim 7.4.629

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -145,7 +145,7 @@ class Manager(object):
 
     def _defineCommonMaps(self):
         normal_map = lfEval("get(g:, 'Lf_NormalMap', {})")
-        if "_" not in normal_map: 
+        if "_" not in normal_map:
             return
 
         for [lhs, rhs] in normal_map["_"]:
@@ -1872,7 +1872,7 @@ class Manager(object):
                 self._getInstance().exitBuffer()
 
             # https://github.com/Yggdroot/LeaderF/issues/257
-            win_local_cwd = lfEval("getcwd(winnr())")
+            win_local_cwd = lfEval("getcwd()")
             if cwd != win_local_cwd:
                 chdir(cwd)
 
@@ -1909,7 +1909,7 @@ class Manager(object):
                     self._getInstance().exitBuffer()
 
             # https://github.com/Yggdroot/LeaderF/issues/257
-            win_local_cwd = lfEval("getcwd(winnr())")
+            win_local_cwd = lfEval("getcwd()")
             if cwd != win_local_cwd:
                 chdir(cwd)
 
@@ -2244,7 +2244,7 @@ class Manager(object):
         self._bang_count = 0
 
         self._getInstance().buffer.vars['Lf_category'] = self._getExplorer().getStlCategory()
- 
+
         self._read_content_exception = None
         if isinstance(content, list):
             self._is_content_list = True
@@ -2283,7 +2283,7 @@ class Manager(object):
                 if not remember_last_status and not self._cli.pattern and empty_query:
                     self._gotoFirstLine()
                     self._guessSearch(self._content)
-                    if self._result_content: # self._result_content is [] only if 
+                    if self._result_content: # self._result_content is [] only if
                                              #  self._cur_buffer.name == '' or self._cur_buffer.options["buftype"] not in [b'', '']:
                         self._getInstance().appendBuffer(self._result_content[self._initial_count:])
                     else:
@@ -2419,7 +2419,7 @@ class Manager(object):
                 elif self._empty_query and self._getExplorer().getStlCategory() in ["File"]:
                     self._guessSearch(self._content)
                     if bang:
-                        if self._result_content: # self._result_content is [] only if 
+                        if self._result_content: # self._result_content is [] only if
                                                  #  self._cur_buffer.name == '' or self._cur_buffer.options["buftype"] != b'':
                             self._getInstance().appendBuffer(self._result_content[self._initial_count:])
                         else:


### PR DESCRIPTION
fixed `vim.error: Vim:E118: 函数的参数过多: getcwd` in vim 7.4.629

It is caused by `getcwd(winnr())` in `line 1912` in `manager.py`

I have tested this PR in vim 8.1 and nvim0.5+， no bugs found

![image](https://user-images.githubusercontent.com/4470821/156707119-e9d832bd-5275-44f4-b2f2-23c47ad4348f.png)
