### PR TITLE
Fix g:Lf_PopupPosition in neovim

### DIFF
--- a/autoload/leaderf/python/leaderf/instance.py
+++ b/autoload/leaderf/python/leaderf/instance.py
@@ -425,6 +425,7 @@ class LfInstance(object):
             col = 1
 
         if lfEval("has('nvim')") == '1':
+            line -= 1
             col -= 1
 
         self._popup_maxheight = max(maxheight - 2, 1) # there is an input window above


### PR DESCRIPTION
If set g:Lf_PopupPosition to [1, 0], then the search window will not
show from the first line in neovim. Fix it.

Signed-off-by: Adam Tao <tcx4c70@gmail.com>