### PR TITLE
fixe issue #928

### DIFF
--- a/autoload/leaderf/python/leaderf/gtagsExpl.py
+++ b/autoload/leaderf/python/leaderf/gtagsExpl.py
@@ -862,7 +862,7 @@ class GtagsExplorer(Explorer):
         def print_log(args):
             print(args)
 
-        if error:
+        if proc.returncode != 0:
             if self._has_nvim:
                 vim.async_call(print_log, cmd)
                 vim.async_call(print_log, error)


### PR DESCRIPTION
warning and error both output to stderr. So error is not null. The issue happens.
Now use the return code to avoid take warning as error.