### PR TITLE
install.bat use --build-lib instead of copy file

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -11,31 +11,22 @@ if /i "%1" equ "--reverse" (
 )
 echo Begin to compile C extension of Python2 ...
 cd autoload\leaderf\fuzzyMatch_C
-py -2 setup.py build
-if %errorlevel% neq 0 goto second
-pushd build\lib*2.*
-xcopy /y *.pyd ..\..\..\python\
+py -2 setup.py build --build-lib ..\python
 if %errorlevel% equ 0 (
     echo=
     echo ===============================================
     echo  C extension of Python2 installed sucessfully!
     echo ===============================================
 )
-popd
 
-:second
 echo=
 echo Begin to compile C extension of Python3 ...
-py -3 setup.py build
-if %errorlevel% neq 0 goto end
-pushd build\lib*3.*
-xcopy /y *.pyd ..\..\..\python\
+py -3 setup.py build --build-lib ..\python
 if %errorlevel% equ 0 (
     echo=
     echo ===============================================
     echo  C extension of Python3 installed sucessfully!
     echo ===============================================
 )
-popd
 
 :end


### PR DESCRIPTION
same as the `install.sh` way

when build with python 3.11, the `.pyd` file is in `lib.win-amd64-cpython-311`. can not pushd use `pushd build\lib*3.*`