### PR TITLE
修正中文檔名無法寫入mruCache問題

### DIFF
--- a/autoload/leaderf/python/leaderf/mru.py
+++ b/autoload/leaderf/python/leaderf/mru.py
@@ -60,7 +60,7 @@ class Mru(object):
         if not buf_names:
             return
 
-        with lfOpen(self._cache_file, 'r+', errors='ignore') as f:
+        with lfOpen(self._cache_file, 'r+', errors='ignore', encoding='utf-8') as f:
             lines = f.readlines()
             for name in buf_names:
                 nocase = False

--- a/autoload/leaderf/python/leaderf/mruExpl.py
+++ b/autoload/leaderf/python/leaderf/mruExpl.py
@@ -31,7 +31,7 @@ class MruExplorer(Explorer):
         mru.saveToCache(lfEval("readfile(lfMru#CacheFileName())"))
         lfCmd("call writefile([], lfMru#CacheFileName())")
 
-        with lfOpen(mru.getCacheFileName(), 'r+', errors='ignore') as f:
+        with lfOpen(mru.getCacheFileName(), 'r+', errors='ignore', encoding='utf8') as f:
             lines = f.readlines()
             lines = [name for name in lines if os.path.exists(lfDecode(name.rstrip()))]
             f.seek(0)
@@ -102,7 +102,7 @@ class MruExplorer(Explorer):
         return True
 
     def delFromCache(self, name):
-        with lfOpen(mru.getCacheFileName(), 'r+', errors='ignore') as f:
+        with lfOpen(mru.getCacheFileName(), 'r+', errors='ignore', encoding='utf8') as f:
             lines = f.readlines()
             lines.remove(lfEncode(os.path.abspath(lfDecode(name))) + '\n')
             f.seek(0)


### PR DESCRIPTION
在 vim9 、python10 及 windows10 中文版的環境中，mruExpl 及 mru 在將中文檔名寫入 mruCache 會出現encoding錯誤，而無法記錄最近開啟的中文檔，爰修正將檔名指定以utf8編碼寫入mruCache。