### PR TITLE
add leader#execute func if execute() function not exists

### DIFF
--- a/autoload/leaderf.vim
+++ b/autoload/leaderf.vim
@@ -327,6 +327,17 @@ endfunction
 
 call s:InitCommandMap('g:Lf_CommandMap', s:Lf_CommandMap)
 
+function! leaderf#execute(cmd)
+    if exists('*execute')
+        return execute(a:cmd)
+    else
+        redir => l:output
+        silent! execute a:cmd
+        redir END
+        return l:output
+    endif
+endfunction
+
 function! leaderf#versionCheck()
     if g:Lf_PythonVersion == 2 && pyeval("sys.version_info < (2, 7)")
         echohl Error

--- a/autoload/leaderf/python/leaderf/commandExpl.py
+++ b/autoload/leaderf/python/leaderf/commandExpl.py
@@ -12,7 +12,7 @@ from .manager import *
 RE_USER_DEFINED_COMMAND = re.compile(r"^.{4}(\w+)")
 
 # index.txt line
-# "|:silent|	:sil[ent]	..."
+# "|:silent|    :sil[ent]       ..."
 #    ^^^^^^
 RE_BUILT_IN_COMMAND = re.compile(r"^\|:([^|]+)\|")
 
@@ -33,7 +33,7 @@ class CommandExplorer(Explorer):
         result_list = []
 
         # user-defined Ex commands
-        result = lfEval("execute('command')")
+        result = lfEval("leaderf#execute('command')")
 
         for line in result.splitlines()[2:]:
             match = RE_USER_DEFINED_COMMAND.match(line)

--- a/autoload/leaderf/python/leaderf/jumpsExpl.py
+++ b/autoload/leaderf/python/leaderf/jumpsExpl.py
@@ -21,7 +21,7 @@ class JumpsExplorer(Explorer):
         return self.getFreshContent(*args, **kwargs)
 
     def getFreshContent(self, *args, **kwargs):
-        content = lfEval("split(execute('jumps'), '\n')")
+        content = lfEval("split(leaderf#execute('jumps'), '\n')")
 
         flag = ' '
         self._content = []


### PR DESCRIPTION
in vim7.4, no function `execute()` exists, so `leader jumps`, `leaderf command` would raise errors,  this commit fixed this bug