### PR TITLE
simplify argdelete and prefix path to multi file selection

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -184,8 +184,8 @@ class Manager(object):
 
     @removeDevIcons
     def _argaddFiles(self, files):
-        # It will raise E480 without 'silent!'
-        lfCmd("silent! argdelete *")
+        # simply delete all, without err print
+        lfCmd("%argdelete")
         for file in files:
             lfCmd("argadd %s" % escSpecial(file))
 

--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -187,6 +187,13 @@ class Manager(object):
         # simply delete all, without err print
         lfCmd("%argdelete")
         for file in files:
+            if not os.path.isabs(file):
+                if self._getExplorer()._cmd_work_dir:
+                    file = os.path.join(self._getExplorer()._cmd_work_dir, lfDecode(file))
+                else:
+                    file = os.path.join(self._getInstance().getCwd(), lfDecode(file))
+                file = os.path.normpath(lfEncode(file))
+
             lfCmd("argadd %s" % escSpecial(file))
 
     def _issue_422_set_option(self):


### PR DESCRIPTION
The first commit is simply modify the 'argdelete' cmd;

The second commit fix the issue in multi seletion with path argument provided like `leader file /path/to/files`.
In multi selection those files need to be prefixed with cwd.