### PR TITLE
support MSYS python enviroment

### DIFF
--- a/autoload/leaderf/fuzzyMatch_C/setup.py
+++ b/autoload/leaderf/fuzzyMatch_C/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import platform
 
 try:
     from setuptools import setup
@@ -8,7 +9,7 @@ except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
 
-if os.name == 'nt':
+if os.name == 'nt' and ("MSC" in platform.python_compiler()):
     from distutils.msvccompiler import get_build_version
 
     if get_build_version() < 14.0: # Visual Studio 2015

--- a/install.bat
+++ b/install.bat
@@ -1,4 +1,9 @@
 @echo off
+set pyFlag=0
+where /Q py
+if %ERRORLEVEL% NEQ 0 set pyFlag=1
+echo pyFlag=%pyFlag%
+
 if /i "%1" equ "--reverse" (
     cd autoload\leaderf\fuzzyMatch_C
     rd /s /q build
@@ -11,7 +16,12 @@ if /i "%1" equ "--reverse" (
 )
 echo Begin to compile C extension of Python2 ...
 cd autoload\leaderf\fuzzyMatch_C
-py -2 setup.py build --build-lib ..\python
+
+if %pyFlag% EQU 0 (
+	py -2 setup.py build --build-lib ..\python
+) else (
+	python2 setup.py build --build-lib ..\python
+)
 if %errorlevel% equ 0 (
     echo=
     echo ===============================================
@@ -21,7 +31,11 @@ if %errorlevel% equ 0 (
 
 echo=
 echo Begin to compile C extension of Python3 ...
-py -3 setup.py build --build-lib ..\python
+if %pyFlag% EQU 0 (
+	py -3 setup.py build --build-lib ..\python
+) else (
+	python3 setup.py build --build-lib ..\python
+)
 if %errorlevel% equ 0 (
     echo=
     echo ===============================================


### PR DESCRIPTION
In msys/mingw/ucrt python enviroment, the `install.bat` will not find `py.exe` and python was build using gccc not msvc. So `:LeaderfInstallCExtension` will fail.