### PR TITLE
Set preview window title

### DIFF
--- a/autoload/leaderf/python/leaderf/manager.py
+++ b/autoload/leaderf/python/leaderf/manager.py
@@ -768,7 +768,7 @@ class Manager(object):
             if show_borders:
                 config["border"] = borderchars
                 if lfEval("has('nvim-0.9.0')") == '1':
-                    config["title"] = " Preview "
+                    config["title"] = f" {title} "
                     config["title_pos"] = "center"
 
             self._createPreviewWindow(config, source, line_num, jump_cmd)
@@ -838,7 +838,7 @@ class Manager(object):
                 line = maxheight + 1
 
             options = {
-                    "title":           " Preview ",
+                    "title":           f" {title} ",
                     "maxwidth":        maxwidth,
                     "minwidth":        maxwidth,
                     "maxheight":       maxheight,
@@ -1031,8 +1031,12 @@ class Manager(object):
         """
         self._is_previewed = True
         line_num = int(line_num)
+        if isinstance(title, int):
+            title = lfEval('bufname(%d)' % title)
+        title = lfEval('fnamemodify("%s", ":~:.")' % (title or 'Preview'))
 
         if self.isPreviewWindowOpen():
+            lfCmd("call popup_setoptions(%d, %s)" % (self._preview_winid, str({'title': f' {title} '})))
             self._useExistingWindow(title, source, line_num, jump_cmd)
             return False
 
@@ -1131,6 +1135,8 @@ class Manager(object):
                     "noautocmd": 1
                     }
 
+            if lfEval("has('nvim-0.9.0')") == '1':
+                config.update({"title": f" {title} ", "title_pos": "center"})
             self._updateOptions(preview_pos, show_borders, config)
             self._createPreviewWindow(config, source, line_num, jump_cmd)
         else:
@@ -1198,7 +1204,7 @@ class Manager(object):
                 col = self._getInstance().window.col + self._getInstance().window.width - maxwidth + 1
 
             options = {
-                    "title":           " Preview ",
+                    "title":           f" {title} ",
                     "maxwidth":        maxwidth,
                     "minwidth":        maxwidth,
                     "maxheight":       maxheight,
@@ -1249,9 +1255,6 @@ class Manager(object):
                 options["border"] = borderchars
                 options["height"] -= 2
                 options["width"] -= 2
-                if lfEval("has('nvim-0.9.0')") == '1':
-                    options["title"] = " Preview "
-                    options["title_pos"] = "center"
         else:
             if preview_pos.lower() == 'cursor':
                 options["maxwidth"] = self._getInstance().window.width

--- a/autoload/leaderf/python/leaderf/rgExpl.py
+++ b/autoload/leaderf/python/leaderf/rgExpl.py
@@ -1277,7 +1277,7 @@ class RgExplManager(Manager):
             else:
                 source = file
 
-        self._createPopupPreview("", source, line_num)
+        self._createPopupPreview(source, source, line_num)
 
     def outputToQflist(self, *args, **kwargs):
         items = self._getFormatedContents()


### PR DESCRIPTION
The preview window always comes with ` Preview ` title, which is good but sometimes not that useful. This PR including changes:

* if `argument title` keeps empty, then it means the title doesn't matter and still use ` Preview `.
* if `argument title` is not empty, then show the actual title rather than default ` Preview `.